### PR TITLE
make repluggableAppDebug.utils.apis getter that return all installed apis

### DIFF
--- a/src/appHost.ts
+++ b/src/appHost.ts
@@ -91,6 +91,7 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
     const trace: Trace[] = []
     const memoizedArr: StatisticsMemoization[] = []
 
+    let readyAPIsVersion = 0 // for tracking changes in readyAPIs to clear cache for repluggableAppDebug.utils.apis
     const readyAPIs = new Set<AnySlotKey>()
 
     const uniqueShellNames = new Set<string>()
@@ -125,6 +126,7 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
 
     setupDebugInfo({
         host,
+        getReadyAPIsVersion: () => readyAPIsVersion,
         readyAPIs,
         uniqueShellNames,
         extensionSlots,
@@ -596,7 +598,7 @@ miss: ${memoizedWithMissHit.miss}
 
     function discardSlotKey<T>(key: SlotKey<T>) {
         const ownKey = getOwnSlotKey(key)
-
+        readyAPIsVersion++
         readyAPIs.delete(ownKey)
         extensionSlots.delete(ownKey)
         slotKeysByName.delete(slotKeyToName(ownKey))
@@ -788,7 +790,7 @@ miss: ${memoizedWithMissHit.miss}
 
                 APILayers.set(key, !options.disableLayersValidation && entryPoint.layer ? getLayerByName(entryPoint.layer) : undefined)
                 apiSlot.contribute(shell, monitoredAPI)
-
+                readyAPIsVersion++
                 readyAPIs.add(key)
 
                 if (canInstallReadyEntryPoints) {

--- a/src/repluggableAppDebug/debug.d.ts
+++ b/src/repluggableAppDebug/debug.d.ts
@@ -20,7 +20,8 @@ export interface RepluggableAppDebugInfo {
 }
 
 export interface RepluggableDebugUtils {
-    apis(): APIDebugInfo[]
+    apis: Record<string, unknown>
+    getApis(): APIDebugInfo[]
     unReadyEntryPoints(): EntryPoint[]
     whyEntryPointUnready(name: string): void
     findAPI(name: string): APIDebugInfo[]

--- a/src/utils/getDuplicates.ts
+++ b/src/utils/getDuplicates.ts
@@ -1,0 +1,12 @@
+export function getDuplicates<T>(array: T[]): Set<T> {
+    const seen = new Set<T>()
+    const duplicates = new Set<T>()
+
+    array.forEach(curr => {
+        if (seen.has(curr)) {
+            duplicates.add(curr)
+        }
+        seen.add(curr)
+    })
+    return duplicates
+}


### PR DESCRIPTION
To simplify debug process make utils.api getter that will return object with api slug name as a key and getter to API.