### PR TITLE
Extend connect shouldComponentUpdate option with additional argument

### DIFF
--- a/test/connectWithShell.spec.tsx
+++ b/test/connectWithShell.spec.tsx
@@ -230,6 +230,32 @@ describe('connectWithShell', () => {
         expect(func2).not.toHaveBeenCalled()
     })
 
+    it('should pass ownProps to shouldComponentUpdate', () => {
+        const { shell, renderInShellContext } = createMocks(mockPackage)
+
+        interface CompOwnProps {
+            ownProp: boolean
+        }
+        const ownPropsSpy = jest.fn()
+        const PureComp: FunctionComponent<CompOwnProps> = () => {
+            return <div>Pure Comp</div>
+        }
+
+        const ConnectedComp = connectWithShell<{}, CompOwnProps>(undefined, undefined, shell, {
+            shouldComponentUpdate: (_shell, _ownProps) => {
+                ownPropsSpy(_ownProps)
+
+                return false
+            },
+            allowOutOfEntryPoint: true
+        })(PureComp)
+
+        renderInShellContext(<ConnectedComp ownProp={true} />)
+
+        expect(ownPropsSpy).toHaveBeenCalledTimes(1)
+        expect(ownPropsSpy).toHaveBeenCalledWith({ ownProp: true })
+    })
+
     it('should pass scoped state to mapStateToProps', () => {
         const { host, shell, renderInShellContext } = createMocks(mockPackage)
 


### PR DESCRIPTION
Attempt to make shouldComponentUpdate connect option compatible with redux connect(areOwnPropsEqual, etc.).
By exposing ownProps/stateProps to shouldComponentUpdate connect options.

Why?
The result of shouldComponentUpdate mainly controlled by API from shell and it's not possible to do via props, so I can't control optimisation per component instance.

Example:
In this example, AuthorizationTooltip children is not rendered if `isPerformingAction()` returns true.
In some cases I want children to be rendered, but I can't control it per component instance, only globally.
```
export function createAuthorizationTooltip(boundShell: Shell) {
  return connectWithShell<
    {},
    AuthorizationTooltipProps,
    AuthorizationTooltipStateProps
  >(mapStateToProps, undefined, boundShell, {
    shouldComponentUpdate: (shell) => {
      return !shell.getAPI(MouseAPI).isPerformingAction();
    },
  })(AuthorizationTooltipPure);
}
```

After fix:
Now, I can control optimisation with ownProps.
```
export function createAuthorizationTooltip(boundShell: Shell) {
  return connectWithShell<
    {},
    AuthorizationTooltipProps,
    AuthorizationTooltipStateProps
  >(mapStateToProps, undefined, boundShell, {
    shouldComponentUpdate: (shell, ownProps) => {
      if (ownProps?.skipOptimisation) {
        return true;
      }

      return !shell.getAPI(MouseAPI).isPerformingAction();
    },
  })(AuthorizationTooltipPure);
}
```