### PR TITLE
EDIX-20625 call slot subscribers when host resumes shells installation

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -274,6 +274,10 @@ export interface AppHost {
     readonly options: AppHostOptions
 }
 
+export interface PrivateAppHost extends AppHost {
+    executeWhenFree(identifier: string, callback: () => void): void
+}
+
 export interface MonitoringOptions {
     enablePerformance?: boolean
     readonly disableMonitoring?: boolean
@@ -343,7 +347,7 @@ export type FunctionWithSameArgs<F extends AnyFunction> = (...args: Parameters<F
  * @interface Shell
  * @extends {(Pick<AppHost, Exclude<keyof AppHost, 'getStore' | 'log' | 'options'>>)}
  */
-export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore' | 'log' | 'options'>> {
+export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore' | 'log' | 'options' | 'isInstallingEntryPoints'>> {
     /**
      * Unique name of the matching {EntryPoint}
      */

--- a/src/API.ts
+++ b/src/API.ts
@@ -347,7 +347,7 @@ export type FunctionWithSameArgs<F extends AnyFunction> = (...args: Parameters<F
  * @interface Shell
  * @extends {(Pick<AppHost, Exclude<keyof AppHost, 'getStore' | 'log' | 'options'>>)}
  */
-export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore' | 'log' | 'options' | 'isInstallingEntryPoints'>> {
+export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore' | 'log' | 'options'>> {
     /**
      * Unique name of the matching {EntryPoint}
      */

--- a/src/extensionSlot.ts
+++ b/src/extensionSlot.ts
@@ -7,7 +7,8 @@ import {
     Shell,
     SlotKey,
     CustomExtensionSlot,
-    CustomExtensionSlotHandler
+    CustomExtensionSlotHandler,
+    PrivateAppHost
 } from './API'
 import _ from 'lodash'
 
@@ -20,9 +21,14 @@ const alwaysTrue = () => true
 
 type Unsubscribe = () => void
 
-export function createExtensionSlot<T>(key: SlotKey<T>, host: AppHost, declaringShell?: Shell): PrivateExtensionSlot<T> & AnyExtensionSlot {
+export function createExtensionSlot<T>(
+    key: SlotKey<T>,
+    host: PrivateAppHost,
+    declaringShell?: Shell
+): PrivateExtensionSlot<T> & AnyExtensionSlot {
     let items: ExtensionItem<T>[] = []
     let subscribers: (() => void)[] = []
+    const slotUniqueId = _.uniqueId()
 
     return {
         host,
@@ -43,7 +49,7 @@ export function createExtensionSlot<T>(key: SlotKey<T>, host: AppHost, declaring
             condition: condition || alwaysTrue,
             uniqueId: _.uniqueId(`${fromShell.name}_extItem_`)
         })
-        subscribers.forEach(func => func())
+        host.executeWhenFree(slotUniqueId, () => subscribers.forEach(func => func()))
     }
 
     function getItems(forceAll: boolean = false): ExtensionItem<T>[] {

--- a/test/extensionSlot.spec.ts
+++ b/test/extensionSlot.spec.ts
@@ -1,0 +1,94 @@
+import { SlotKey } from '../src'
+import { addMockShell, createAppHost } from '../testKit/v2'
+import { PrivateExtensionSlot, Shell, EntryPoint } from '../src/API'
+
+describe('ExtensionSlot', () => {
+    describe('Subscribe', () => {
+        it('should be invoked on contribution', () => {
+            const slotKey: SlotKey<{}> = {
+                name: 'mock_key'
+            }
+            const host = createAppHost([])
+            const shell = addMockShell(host)
+            const spy = jest.fn()
+            const slot = shell.declareSlot(slotKey) as PrivateExtensionSlot<{}>
+
+            slot.subscribe(spy)
+
+            slot.contribute(shell, () => ({}))
+
+            expect(spy).toBeCalledTimes(1)
+
+            slot.contribute(shell, () => ({}))
+
+            expect(spy).toBeCalledTimes(2)
+        })
+        it('should be invoked once when contribution is during installation phase', () => {
+            interface SlotItem {
+                name: string
+            }
+            const slotKey: SlotKey<SlotItem> = {
+                name: 'MOCK_SLOT'
+            }
+            interface MockContributionAPI {
+                contributeItem(fromShell: Shell, item: SlotItem): void
+            }
+
+            const ContributionAPI: SlotKey<MockContributionAPI> = {
+                name: 'CONTRIBUTION_API'
+            }
+
+            const spy = jest.fn()
+
+            const contributionEntryPoint: EntryPoint = {
+                name: 'PRIVATE CONTRIBUTION ENTRY POINT',
+                declareAPIs() {
+                    return [ContributionAPI]
+                },
+                attach(shell) {
+                    const slot = shell.declareSlot(slotKey) as PrivateExtensionSlot<SlotItem>
+                    slot.subscribe(spy)
+                    shell.contributeAPI(ContributionAPI, () => ({
+                        contributeItem(fromShell, item) {
+                            shell.getSlot(slotKey).contribute(fromShell, item)
+                        }
+                    }))
+                }
+            }
+
+            const API_A: SlotKey<{}> = { name: 'API_A' }
+
+            const itemContributionEntryPointA: EntryPoint = {
+                name: 'ITEM CONTRIBUTION ENTRY POINT A',
+                getDependencyAPIs() {
+                    return [ContributionAPI]
+                },
+                declareAPIs(): SlotKey<{}>[] {
+                    return [API_A]
+                },
+                attach(shell: Shell) {
+                    shell.contributeAPI(API_A, () => ({}))
+                },
+                extend(shell: Shell) {
+                    shell.getAPI(ContributionAPI).contributeItem(shell, { name: 'A.1' })
+                    shell.getAPI(ContributionAPI).contributeItem(shell, { name: 'A.2' })
+                }
+            }
+
+            const itemContributionEntryPointB: EntryPoint = {
+                name: 'ITEM CONTRIBUTION ENTRY POINT B',
+                getDependencyAPIs() {
+                    return [ContributionAPI, API_A]
+                },
+                extend(shell: Shell) {
+                    shell.getAPI(ContributionAPI).contributeItem(shell, { name: 'B.1' })
+                    shell.getAPI(ContributionAPI).contributeItem(shell, { name: 'B.2' })
+                }
+            }
+
+            createAppHost([contributionEntryPoint, itemContributionEntryPointA, itemContributionEntryPointB])
+
+            expect(spy).toBeCalledTimes(1)
+        })
+    })
+})


### PR DESCRIPTION
Performance measurements
---

### Method
Steps: 
1. Add the code below in `createAppHost`

initialize a flag to indicate if installing shells
<img width="544" alt="CleanShot 2023-06-21 at 19 16 44@2x" src="https://github.com/wix-incubator/repluggable/assets/91830681/3614ef12-c27d-40ad-b6a7-086d3e67a378">

accumulate execution duration of executeInstallShell just before the return statement
<img width="1174" alt="CleanShot 2023-06-21 at 19 17 52@2x" src="https://github.com/wix-incubator/repluggable/assets/91830681/e14ede79-9a9d-4f29-b50a-65dbe5616da7">

2. Run repluggable locally 
3. Run studio with local repluggable - Add `&debug=true` to url params + use directly or any other extension to redirect the request for repluggable to the local host
4. Refresh to load the editor
5. Open dev tools and run `window.total`

**Note** that I also disabled shell logger for these specific measurements.

### Results
Master branch
<img width="293" alt="CleanShot 2023-06-21 at 19 12 34@2x" src="https://github.com/wix-incubator/repluggable/assets/91830681/882a714e-6644-4600-929e-1ef2b65ba59c">

Current branch
<img width="326" alt="CleanShot 2023-06-21 at 19 08 16@2x" src="https://github.com/wix-incubator/repluggable/assets/91830681/0e18bc66-0858-4017-abc5-3ac88d5d5fe1">





