### PR TITLE
Defer notifications while performing action

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -4,7 +4,10 @@ import { ThrottledStore } from './throttledStore'
 
 export { AppHostAPI } from './appHostServices'
 
-export type ScopedStore<S> = Pick<ThrottledStore<S>, 'dispatch' | 'getState' | 'subscribe' | 'flush' | 'hasPendingSubscribers' | 'deferSubscriberNotifications'>
+export type ScopedStore<S> = Pick<
+    ThrottledStore<S>,
+    'dispatch' | 'getState' | 'subscribe' | 'flush' | 'hasPendingSubscribers' | 'deferSubscriberNotifications'
+>
 export type ReactComponentContributor<TProps = {}> = (props?: TProps) => React.ReactNode
 export type ReducersMapObjectContributor<TState = {}, TAction extends Redux.AnyAction = Redux.AnyAction> = () => Redux.ReducersMapObject<
     TState,

--- a/src/API.ts
+++ b/src/API.ts
@@ -471,6 +471,14 @@ export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore' |
      * @param {(Partial<_.MemoizedFunction> & Partial<MemoizeMissHit>)} memoizedFunction
      */
     clearCache(memoizedFunction: Partial<_.MemoizedFunction> & Partial<MemoizeMissHit>): void
+    /**
+     * Defer subscribers notification while performing a function
+     * 
+     * @param func 
+     */
+    deferSubscriberNotifications<T>(
+        func: () => T | Promise<T>,
+    ): Promise<T>
 }
 
 export interface PrivateShell extends Shell {

--- a/src/API.ts
+++ b/src/API.ts
@@ -4,7 +4,7 @@ import { ThrottledStore } from './throttledStore'
 
 export { AppHostAPI } from './appHostServices'
 
-export type ScopedStore<S> = Pick<ThrottledStore<S>, 'dispatch' | 'getState' | 'subscribe' | 'flush' | 'hasPendingSubscribers'>
+export type ScopedStore<S> = Pick<ThrottledStore<S>, 'dispatch' | 'getState' | 'subscribe' | 'flush' | 'hasPendingSubscribers' | 'deferSubscriberNotifications'>
 export type ReactComponentContributor<TProps = {}> = (props?: TProps) => React.ReactNode
 export type ReducersMapObjectContributor<TState = {}, TAction extends Redux.AnyAction = Redux.AnyAction> = () => Redux.ReducersMapObject<
     TState,
@@ -471,14 +471,6 @@ export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore' |
      * @param {(Partial<_.MemoizedFunction> & Partial<MemoizeMissHit>)} memoizedFunction
      */
     clearCache(memoizedFunction: Partial<_.MemoizedFunction> & Partial<MemoizeMissHit>): void
-    /**
-     * Defer subscribers notification while performing a function
-     * 
-     * @param func 
-     */
-    deferSubscriberNotifications<T>(
-        func: () => T | Promise<T>,
-    ): Promise<T>
 }
 
 export interface PrivateShell extends Shell {

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -1057,7 +1057,7 @@ miss: ${memoizedWithMissHit.miss}
                         return entireStoreState[shell.name]
                     },
                     flush: host.getStore().flush,
-                    hasPendingSubscribers: host.getStore().hasPendingSubscribers
+                    hasPendingSubscribers: host.getStore().hasPendingSubscribers,
                     deferSubscriberNotifications: host.getStore().deferSubscriberNotifications
                 }
             },
@@ -1091,9 +1091,7 @@ miss: ${memoizedWithMissHit.miss}
 
             wrapWithShellRenderer(component): JSX.Element {
                 return <ShellRenderer shell={shell} component={component} host={host} />
-            },
-
-            
+            }
         }
 
         return shell

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -1090,7 +1090,20 @@ miss: ${memoizedWithMissHit.miss}
 
             wrapWithShellRenderer(component): JSX.Element {
                 return <ShellRenderer shell={shell} component={component} host={host} />
-            }
+            },
+
+            deferSubscriberNotifications: async (func) => {
+              try {
+                (host.getStore() as PrivateThrottledStore).deferNotifications(true);
+                const functionResult =  await func();
+                return functionResult;
+                
+              }
+              finally {
+                (host.getStore() as PrivateThrottledStore).deferNotifications(false);
+                host.getStore().flush();
+              }            
+            },
         }
 
         return shell

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -1058,6 +1058,7 @@ miss: ${memoizedWithMissHit.miss}
                     },
                     flush: host.getStore().flush,
                     hasPendingSubscribers: host.getStore().hasPendingSubscribers
+                    deferSubscriberNotifications: host.getStore().deferSubscriberNotifications
                 }
             },
 
@@ -1092,18 +1093,7 @@ miss: ${memoizedWithMissHit.miss}
                 return <ShellRenderer shell={shell} component={component} host={host} />
             },
 
-            deferSubscriberNotifications: async (func) => {
-              try {
-                (host.getStore() as PrivateThrottledStore).deferNotifications(true);
-                const functionResult =  await func();
-                return functionResult;
-                
-              }
-              finally {
-                (host.getStore() as PrivateThrottledStore).deferNotifications(false);
-                host.getStore().flush();
-              }            
-            },
+            
         }
 
         return shell

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -211,10 +211,12 @@ export const createThrottledStore = (
     }
 
     const notifyAll = () => {
+        if (deferNotifications) {
+            updateIsObserversNotifyInProgress(true)
+            updateIsSubscriptionNotifyInProgress(true)
+            return
+        }
         try {
-            if (deferNotifications) {
-                return
-            }
             updateIsObserversNotifyInProgress(true)
             notifyObservers()
             updateIsSubscriptionNotifyInProgress(true)
@@ -246,7 +248,10 @@ export const createThrottledStore = (
         return store.dispatch(action)
     }
 
-    const toShellAction = <T extends Action>(shell: Shell, action: T): T => ({ ...action, __shellName: shell.name })
+    const toShellAction = <T extends Action>(shell: Shell, action: T): T => ({
+        ...action,
+        __shellName: shell.name
+    })
 
     const result: PrivateThrottledStore = {
         ...store,
@@ -269,7 +274,8 @@ export const createThrottledStore = (
                 return functionResult
             } finally {
                 deferNotifications = false
-                flush()
+                notifyObservers()
+                notifySubscribers()
             }
         }
     }

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -274,8 +274,6 @@ export const createThrottledStore = (
                 return functionResult
             } finally {
                 deferNotifications = false
-                notifyObservers()
-                notifySubscribers()
             }
         }
     }

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -271,6 +271,8 @@ export const createThrottledStore = (
                 return functionResult
             } finally {
                 deferNotifications = false
+                notifyObservers()
+                notifySubscribers()
             }
         }
     }

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -235,6 +235,9 @@ export const createThrottledStore = (
     })
 
     const flush = () => {
+        if (deferNotifications) {
+            console.error('Cannot flush while notifications are deferred')
+        }
         cancelRender()
         notifyAll()
     }

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -237,9 +237,6 @@ export const createThrottledStore = (
     })
 
     const flush = () => {
-        if (deferNotifications) {
-            console.error('Cannot flush while notifications are deferred')
-        }
         cancelRender()
         notifyAll()
     }

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -46,7 +46,7 @@ export interface StateContribution<TState = {}, TAction extends AnyAction = AnyA
 
 export interface ThrottledStore<T = any> extends Store<T> {
     hasPendingSubscribers(): boolean
-    flush(config?: { excecutionType: 'scheduled' | 'immediate' }): void
+    flush(config?: { excecutionType: 'scheduled' | 'immediate' | 'default' }): void
     deferSubscriberNotifications<K>(action: () => K | Promise<K>): Promise<K>
 }
 
@@ -239,12 +239,14 @@ export const createThrottledStore = (
         cancelRender = notifyAllOnAnimationFrame()
     })
 
-    const flush = (config?: { excecutionType: 'scheduled' | 'immediate' }) => {
-        if (deferNotifications && config?.excecutionType !== 'immediate') {
+    const flush = (config = { excecutionType: 'default' }) => {
+        if (deferNotifications && config.excecutionType !== 'immediate') {
             pendingFlush = true
             return
         }
-        cancelRender()
+        if (config.excecutionType !== 'scheduled') {
+            cancelRender()
+        }
         notifyAll()
     }
 

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -256,18 +256,19 @@ export const createThrottledStore = (
         observableNotify: onObservableNotify,
         resetPendingNotifications: resetAllPendingNotifications,
         hasPendingSubscribers: () => pendingBroadcastNotification,
-        deferSubscriberNotifications: async (action) => {
-            try {
-              deferNotifications = true;
-              const functionResult =  await action();
-              return functionResult;
-              
+        deferSubscriberNotifications: async action => {
+            if (deferNotifications) {
+                return action()
             }
-            finally {
-              deferNotifications = false;
-              flush();
-            }            
-          },
+            try {
+                deferNotifications = true
+                const functionResult = await action()
+                return functionResult
+            } finally {
+                deferNotifications = false
+                flush()
+            }
+        }
     }
 
     resetAllPendingNotifications()

--- a/test/connectWithShell.spec.tsx
+++ b/test/connectWithShell.spec.tsx
@@ -586,6 +586,9 @@ describe('connectWithShell-useCases', () => {
         }
     }
 
+    const getComponentValueByClassName = (className: string, testKit: ReactTestRenderer) =>
+        testKit.root.findByProps({ className }).children[0]
+
     beforeEach(() => {
         renderSpy.mockClear()
         mapStateToPropsSpy.mockClear()
@@ -646,7 +649,7 @@ describe('connectWithShell-useCases', () => {
             throw new Error('Connected component failed to render')
         }
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('init1')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('init1')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
@@ -655,12 +658,12 @@ describe('connectWithShell-useCases', () => {
         await act(async () => {
             await host.getStore().deferSubscriberNotifications(() => {
                 dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)
-                valueOneWhileDeferring = testKit.root.findByProps({ className: 'ONE' }).children[0]
+                valueOneWhileDeferring = getComponentValueByClassName('ONE', testKit)
             })
         })
 
         expect(valueOneWhileDeferring).toBe('init1')
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
     })
@@ -674,7 +677,7 @@ describe('connectWithShell-useCases', () => {
             throw new Error('Connected component failed to render')
         }
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('init1')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('init1')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
@@ -687,7 +690,7 @@ describe('connectWithShell-useCases', () => {
             })
         } catch (e) {}
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
     })
@@ -708,7 +711,7 @@ describe('connectWithShell-useCases', () => {
                 host.getStore().dispatch({ type: 'SET_FIRST_STATE', value: 'update1' })
                 host.getStore().flush({ excecutionType: 'immediate' })
             })
-            valueOneWhileDeferring = testKit.root.findByProps({ className: 'ONE' }).children[0]
+            valueOneWhileDeferring = getComponentValueByClassName('ONE', testKit)
         })
 
         expect(valueOneWhileDeferring).toEqual('update1')
@@ -723,7 +726,7 @@ describe('connectWithShell-useCases', () => {
             throw new Error('Connected component failed to render')
         }
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('init1')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('init1')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
         let valueOneInOuterDeferNotifications
@@ -734,15 +737,15 @@ describe('connectWithShell-useCases', () => {
                 dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update from outer' }, host)
                 await host.getStore().deferSubscriberNotifications(() => {
                     dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update from inner' }, host)
-                    valueOneInInnerDeferNotifications = testKit.root.findByProps({ className: 'ONE' }).children[0]
+                    valueOneInInnerDeferNotifications = getComponentValueByClassName('ONE', testKit)
                 })
-                valueOneInOuterDeferNotifications = testKit.root.findByProps({ className: 'ONE' }).children[0]
+                valueOneInOuterDeferNotifications = getComponentValueByClassName('ONE', testKit)
             })
         })
 
         expect(valueOneInInnerDeferNotifications).toBe('init1')
         expect(valueOneInOuterDeferNotifications).toBe('init1')
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update from inner')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update from inner')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
     })
@@ -773,29 +776,29 @@ describe('connectWithShell-useCases', () => {
             throw new Error('Connected component failed to render')
         }
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('init1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('init1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
         dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
         dispatchAndFlush({ type: 'SET_SECOND_STATE', value: 'update2' }, host)
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('update2')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('update2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(3)
         expect(renderSpy).toHaveBeenCalledTimes(3)
 
         dispatchAndFlush({ type: 'SOME_OTHER_ACTION' }, host)
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('update2')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('update2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(3)
         expect(renderSpy).toHaveBeenCalledTimes(3)
     })
@@ -812,23 +815,23 @@ describe('connectWithShell-useCases', () => {
             throw new Error('Connected component failed to render')
         }
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('init1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('init1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
         dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
         // this should not notify the uninterested component
         dispatchAndFlush({ type: 'SET_FIRST_OBSERVABLE', value: 'update3' }, host)
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
     })
@@ -861,34 +864,34 @@ describe('connectWithShell-useCases', () => {
             throw new Error('Connected component failed to render')
         }
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('init1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
-        expect(testKit.root.findByProps({ className: 'THREE' }).children[0]).toBe('init3')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('init1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
+        expect(getComponentValueByClassName('THREE', testKit)).toBe('init3')
 
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(1)
         expect(renderSpy).toHaveBeenCalledTimes(1)
 
         dispatchAndFlush({ type: 'SET_FIRST_STATE', value: 'update1' }, host)
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
-        expect(testKit.root.findByProps({ className: 'THREE' }).children[0]).toBe('init3')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
+        expect(getComponentValueByClassName('THREE', testKit)).toBe('init3')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(2)
         expect(renderSpy).toHaveBeenCalledTimes(2)
 
         dispatchAndFlush({ type: 'SET_FIRST_OBSERVABLE', value: 'update3' }, host)
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
-        expect(testKit.root.findByProps({ className: 'THREE' }).children[0]).toBe('update3')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
+        expect(getComponentValueByClassName('THREE', testKit)).toBe('update3')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(3)
         expect(renderSpy).toHaveBeenCalledTimes(3)
 
         dispatchAndFlush({ type: 'SOME_OTHER_ACTION' }, host)
 
-        expect(testKit.root.findByProps({ className: 'ONE' }).children[0]).toBe('update1')
-        expect(testKit.root.findByProps({ className: 'TWO' }).children[0]).toBe('init2')
-        expect(testKit.root.findByProps({ className: 'THREE' }).children[0]).toBe('update3')
+        expect(getComponentValueByClassName('ONE', testKit)).toBe('update1')
+        expect(getComponentValueByClassName('TWO', testKit)).toBe('init2')
+        expect(getComponentValueByClassName('THREE', testKit)).toBe('update3')
         expect(mapStateToPropsSpy).toHaveBeenCalledTimes(3)
         expect(renderSpy).toHaveBeenCalledTimes(3)
     })

--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -258,7 +258,8 @@ function createShell(host: AppHost): PrivateShell {
         clearCache: _.noop,
         getHostOptions: () => host.options,
         log: createShellLogger(host, entryPoint),
-        wrapWithShellRenderer: (component: JSX.Element) => component
+        wrapWithShellRenderer: (component: JSX.Element) => component,
+        deferSubscriberNotifications: _.identity,
     }
 }
 

--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -258,7 +258,7 @@ function createShell(host: AppHost): PrivateShell {
         clearCache: _.noop,
         getHostOptions: () => host.options,
         log: createShellLogger(host, entryPoint),
-        wrapWithShellRenderer: (component: JSX.Element) => component,
+        wrapWithShellRenderer: (component: JSX.Element) => component
     }
 }
 

--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -259,7 +259,6 @@ function createShell(host: AppHost): PrivateShell {
         getHostOptions: () => host.options,
         log: createShellLogger(host, entryPoint),
         wrapWithShellRenderer: (component: JSX.Element) => component,
-        deferSubscriberNotifications: _.identity,
     }
 }
 


### PR DESCRIPTION
- Add `deferSubscriberNotifications` Function that defers subscribers (and observables) notification until the end of some action. This is necessary when running a flow that creates intermediate states we don't want to react to. 

- To handle the conflict between `deferSubscriberNotifications` and `flush`, add optional config to the flush function:
   - `excecutionType: scheduled`- meaning flush would happen right after we stop deferring notifications
   - `excecutionType: immediate` - meaning flush would happen immediately regardless if notifications are currently being deferred.


In general, the `deferSubscriberNotifications` solution is:

- `deferSubscriberNotifications` receives some action we would like to perform while deferring notifications.
- If notifications are already deferred, run action without doing anything else (to support nesting `deferSubscriberNotifications`)
-  Set `deferNotifications` flag to true before running the action
-  When calling `notifyAll` while `deferNotifications` is set to true, return without notifying
-  Finally, set `deferNotifications` back to false, and flush\notify if someone tried to flush (not immediate) or notify while deferring notifications.