### PR TITLE
Notify if needed before deferring subscriber notifications

### DIFF
--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -264,8 +264,11 @@ export const createThrottledStore = (
             pendingFlush = false
             flush()
         }
-        if (pendingBroadcastNotification || !pendingObservableNotifications) {
-            notifyAll()
+        if (pendingBroadcastNotification) {
+            notifySubscribers()
+        }
+        if (pendingObservableNotifications) {
+            notifyObservers()
         }
     }
 

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -259,6 +259,16 @@ export const createThrottledStore = (
         __shellName: shell.name
     })
 
+    const excecutePendingActions = () => {
+        if (pendingFlush) {
+            pendingFlush = false
+            flush()
+        }
+        if (pendingBroadcastNotification || !pendingObservableNotifications) {
+            notifyAll()
+        }
+    }
+
     const result: PrivateThrottledStore = {
         ...store,
         subscribe,
@@ -275,20 +285,13 @@ export const createThrottledStore = (
                 return action()
             }
             try {
-                if (pendingBroadcastNotification || !pendingObservableNotifications) {
-                    notifyAll()
-                }
+                excecutePendingActions()
                 deferNotifications = true
                 const functionResult = await action()
                 return functionResult
             } finally {
                 deferNotifications = false
-                if (pendingFlush) {
-                    pendingFlush = false
-                    flush()
-                } else {
-                    notifyAll()
-                }
+                excecutePendingActions()
             }
         }
     }

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -259,7 +259,7 @@ export const createThrottledStore = (
         __shellName: shell.name
     })
 
-    const excecutePendingActions = () => {
+    const executePendingActions = () => {
         if (pendingFlush) {
             pendingFlush = false
             flush()
@@ -285,13 +285,13 @@ export const createThrottledStore = (
                 return action()
             }
             try {
-                excecutePendingActions()
+                executePendingActions()
                 deferNotifications = true
                 const functionResult = await action()
                 return functionResult
             } finally {
                 deferNotifications = false
-                excecutePendingActions()
+                executePendingActions()
             }
         }
     }

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -275,7 +275,9 @@ export const createThrottledStore = (
                 return action()
             }
             try {
-                notifyAll()
+                if (pendingBroadcastNotification || !pendingObservableNotifications) {
+                    notifyAll()
+                }
                 deferNotifications = true
                 const functionResult = await action()
                 return functionResult

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -264,11 +264,8 @@ export const createThrottledStore = (
             pendingFlush = false
             flush()
         }
-        if (pendingBroadcastNotification) {
-            notifySubscribers()
-        }
-        if (pendingObservableNotifications) {
-            notifyObservers()
+        if (pendingBroadcastNotification || pendingObservableNotifications) {
+            notifyAll()
         }
     }
 

--- a/src/throttledStore.tsx
+++ b/src/throttledStore.tsx
@@ -275,6 +275,7 @@ export const createThrottledStore = (
                 return action()
             }
             try {
+                notifyAll()
                 deferNotifications = true
                 const functionResult = await action()
                 return functionResult


### PR DESCRIPTION
This PR fixes a bug with `deferSubscriberNotifications`, where it's called right after a state update. 

In general, when dispatching a state update, we update `pendingBroadcastNotification` and notify all on the next animation frame. 
When calling `deferSubscriberNotifications` right after a dispatch, we face with a case where we should have notified subscribers, but there was no animation frame yet, and so we start deferring notification before notifying on the previous state update. Meaning, we do not notify about the state update that happened right before we started deferring until we stop deferring all notifications.

This is an unexpected behaviour, and to solve this, this PR adds executes all pending actions before starting to defer notifications, in case there are pending subscribers\observables\flush.
