### PR TITLE
arePropsEqualFuncWrapper

### DIFF
--- a/src/connectWithShell.tsx
+++ b/src/connectWithShell.tsx
@@ -48,18 +48,18 @@ function arePropsEqualFuncWrapper<Props extends unknown, F extends (next: Props,
     if (!componentShouldUpdateFunc) {
         return arePropsEqualFunc
     }
-    let changeInPropsDetected = false
+    let hasPendingPropChanges = false
     return ((...args: Parameters<F>) => {
         const componentShouldUpdate = componentShouldUpdateFunc(shell, getOwnProps())
         if (componentShouldUpdate) {
-            if (changeInPropsDetected) {
-                changeInPropsDetected = false
+            if (hasPendingPropChanges) {
+                hasPendingPropChanges = false
                 return false
             }
             return arePropsEqualFunc(args[0], args[1])
         }
-        if (!changeInPropsDetected) {
-            changeInPropsDetected = !arePropsEqualFunc(args[0], args[1])
+        if (!hasPendingPropChanges) {
+            hasPendingPropChanges = !arePropsEqualFunc(args[0], args[1])
         }
         return true
     }) as F

--- a/test/connectWithShell.spec.tsx
+++ b/test/connectWithShell.spec.tsx
@@ -313,7 +313,7 @@ describe('connectWithShell', () => {
             allowOutOfEntryPoint: true
         })(PureOuterComp)
 
-        // SetUp - use a reducer that creates a new state for any dispatch action
+        // SetUp - use a reducer that creates a new state for any dispatched action
         let counter = 0
         host.getStore().replaceReducer(() => ({
             counter: ++counter
@@ -346,7 +346,7 @@ describe('connectWithShell', () => {
             .props.onClick()
         expect(onClickSpy).toHaveBeenCalledWith(1)
 
-        // Act - update outer component
+        // Act - update outer component, while updates for inner component are blocked
         updateOuterComp({ num: 2, str: 'nextState_1' })
         expect(mapStateSpy).toHaveBeenCalledTimes(2)
         expect(outerComponentRenderSpy).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
### Problem Description

In Redux, the calculation of the `mergedProps` depends on determining whether `ownProps` have changed. If `ownProps` change while `shouldComponentUpdate` is blocking the recalculation of `mergedProps`, a subsequent state update or propagation of seemingly unchanged `ownProps` (which appear the same as the last `ownProps` but differ from the `ownProps` before the blocking period) may result in incorrect `mergedProps` calculation. This issue arises because changes in `ownProps` during the blocking period are not taken into account.

### Solution

This PR introduces a mechanism to detect changes in `ownProps` that occur while `shouldComponentUpdate` optimization is in effect. If such changes are detected during this blocking period, the next permitted component update will trigger a recalculation of `mergedProps` considering the updated `ownProps`.

### Additional Information

For more details on how Redux calculates `mergedProps` and the role of `areOwnPropsEqual` in this process, please refer to the following link: [Redux - selectorFactory.ts](https://github.com/reduxjs/react-redux/blob/master/src/connect/selectorFactory.ts#L133)
