### PR TITLE
Add shell.lazyEvaluator

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -342,6 +342,10 @@ export interface ObservableState<TSelectorAPI> {
 export type AnyFunction = (...args: any[]) => any
 export type FunctionWithSameArgs<F extends AnyFunction> = (...args: Parameters<F>) => any
 
+export interface Lazy<T> {
+    get(): T
+}
+
 /**
  * An scoped communication terminal provided for an {EntryPoint}
  * in order to contribute its application content to the {AppHost}
@@ -474,6 +478,15 @@ export interface Shell extends Pick<AppHost, Exclude<keyof AppHost, 'getStore' |
      * @param {(Partial<_.MemoizedFunction> & Partial<MemoizeMissHit>)} memoizedFunction
      */
     clearCache(memoizedFunction: Partial<_.MemoizedFunction> & Partial<MemoizeMissHit>): void
+    /**
+     * Creates a lazy-evaluated value. The function `func` is only executed once when `get` is called for the first time,
+     * and the result is cached for subsequent calls.
+     *
+     * @template T
+     * @param {F} func - The function that will be lazily evaluated. It should not take any arguments.
+     * @returns {Lazy<T>} An object with a `get` method that returns the lazily evaluated value of type `T`.
+     */
+    lazyEvaluator<F extends AnyFunction, T extends ReturnType<F>>(func: F): Lazy<T>
 }
 
 export interface PrivateShell extends Shell {

--- a/src/appHost.tsx
+++ b/src/appHost.tsx
@@ -9,6 +9,7 @@ import {
     EntryPointsInfo,
     ExtensionItem,
     ExtensionSlot,
+    Lazy,
     LazyEntryPointDescriptor,
     LazyEntryPointFactory,
     PrivateShell,
@@ -235,6 +236,22 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
             }
         }
         return enrichedMemoization
+    }
+
+    function lazyEvaluator<F extends AnyFunction, T extends ReturnType<F>>(fn: F): Lazy<T> {
+        let _value: T
+        let _resolved: boolean = false
+
+        return {
+            get: () => {
+                if (!_resolved) {
+                    _value = fn()
+                    _resolved = true
+                }
+
+                return _value
+            }
+        }
     }
 
     // we know that addShells completes synchronously
@@ -1092,7 +1109,8 @@ miss: ${memoizedWithMissHit.miss}
 
             wrapWithShellRenderer(component): JSX.Element {
                 return <ShellRenderer shell={shell} component={component} host={host} />
-            }
+            },
+            lazyEvaluator
         }
 
         return shell

--- a/test/appHost.spec.ts
+++ b/test/appHost.spec.ts
@@ -933,6 +933,18 @@ describe('App Host', () => {
                 }
             })
         })
+
+        describe('lazyEvaluator', () => {
+            it('should return a getter that is evaluated only once', () => {
+                const { helperShell } = createHostWithDependantPackages(MockAPI)
+                const func = jest.fn(() => 42)
+                const lazyEval = helperShell.lazyEvaluator(func)
+
+                expect(lazyEval.get()).toBe(42)
+                expect(lazyEval.get()).toBe(42)
+                expect(func).toHaveBeenCalledTimes(1)
+            })
+        })
     })
 
     describe('Entry Point Shell Scoping', () => {

--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -259,7 +259,7 @@ function createShell(host: AppHost): PrivateShell {
         getHostOptions: () => host.options,
         log: createShellLogger(host, entryPoint),
         wrapWithShellRenderer: (component: JSX.Element) => component,
-        lazyEvaluator: _.identity
+        lazyEvaluator: func => ({ get: func })
     }
 }
 

--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -258,7 +258,8 @@ function createShell(host: AppHost): PrivateShell {
         clearCache: _.noop,
         getHostOptions: () => host.options,
         log: createShellLogger(host, entryPoint),
-        wrapWithShellRenderer: (component: JSX.Element) => component
+        wrapWithShellRenderer: (component: JSX.Element) => component,
+        lazyEvaluator: _.identity
     }
 }
 


### PR DESCRIPTION
Add @DanielKag's amazing `lazy` logic, that given a function creates an object with a lazy-evaluated getter for that function (calculated only once).