### PR TITLE
Bug fix: interceptAnyObject used in monitorAPI

### DIFF
--- a/src/interceptAnyObject.ts
+++ b/src/interceptAnyObject.ts
@@ -1,34 +1,39 @@
 import _ from 'lodash'
 
-export interface AnyObject {
-    [key: string]: any
-}
 export type FunctionInterceptor = (name: string, original: Function) => Function
 export type PropertyInterceptor = (name: string, original: any) => any
 
-export function interceptAnyObject<T extends AnyObject>(
+export interface AnyObject {
+    [key: string]: any
+}
+const isPlainObject = (value: any): value is AnyObject => _.isPlainObject(value)
+
+export function interceptAnyObject<T>(
     inner: T,
     onFunction?: FunctionInterceptor,
     onProperty?: PropertyInterceptor,
     includeNestedLevels?: number
 ): T {
-    const result = _.mapValues(inner, (original, key) => {
-        if (typeof original === 'function' && typeof onFunction === 'function') {
-            return onFunction(key, original)
-        }
-        if (includeNestedLevels && _.isObjectLike(original)) {
-            return interceptAnyObject(
-                original,
-                onFunction ? (name, func) => onFunction(`${key}.${name}`, func) : undefined,
-                onProperty ? (name, value) => onProperty(`${key}.${name}`, value) : undefined,
-                includeNestedLevels - 1
-            )
-        }
-        if (typeof onProperty === 'function') {
-            return onProperty(key, original)
-        }
-        return original
-    }) as T
+    if (isPlainObject(inner)) {
+        const result = _.mapValues(inner, (original, key) => {
+            if (typeof original === 'function' && typeof onFunction === 'function') {
+                return onFunction(key, original)
+            }
+            if (includeNestedLevels && _.isPlainObject(original)) {
+                return interceptAnyObject(
+                    original,
+                    onFunction ? (name, func) => onFunction(`${key}.${name}`, func) : undefined,
+                    onProperty ? (name, value) => onProperty(`${key}.${name}`, value) : undefined,
+                    includeNestedLevels - 1
+                )
+            }
+            if (typeof onProperty === 'function') {
+                return onProperty(key, original)
+            }
+            return original
+        }) as T
 
-    return result
+        return result
+    }
+    return inner
 }

--- a/src/monitorAPI.ts
+++ b/src/monitorAPI.ts
@@ -39,7 +39,7 @@ export function monitorAPI<TAPI>(
             : () => true
 
     return interceptAnyObject(
-        api as any,
+        api,
         (funcName, originalFunc) => {
             if (!shouldMonitor(funcName)) {
                 console.log('DISABLED MONITORING>', funcName)

--- a/test/interceptAnyObject.spec.ts
+++ b/test/interceptAnyObject.spec.ts
@@ -197,12 +197,7 @@ describe('interceptAnyObject', () => {
     it('should not intercept non object-like values - primitives', () => {
         const spy: LogSpy = jest.fn()
         const real = 'real'
-        const intercepted = interceptAnyObject(
-            // @ts-ignore
-            real,
-            createFuncInterceptor(spy),
-            createPropInterceptor(spy)
-        )
+        const intercepted = interceptAnyObject(real, createFuncInterceptor(spy), createPropInterceptor(spy))
         expect(intercepted).toBe('real')
     })
 

--- a/test/interceptAnyObject.spec.ts
+++ b/test/interceptAnyObject.spec.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { interceptAnyObject, FunctionInterceptor, PropertyInterceptor } from '../src/interceptAnyObject'
+import { FunctionInterceptor, interceptAnyObject, PropertyInterceptor } from '../src/interceptAnyObject'
 
 type LogSpy = jest.Mock<void, string[]>
 
@@ -183,5 +183,40 @@ describe('interceptAnyObject', () => {
             'AFTER:objectProp.nestedObject.nestedFuncLevelTwo(12345)'
         ])
         expect(nestedFuncLevelTwoRetVal).toBe(12345)
+    })
+
+    it('should not intercept non object-like values - functions', () => {
+        const spy: LogSpy = jest.fn()
+        function real() {
+            return 'real'
+        }
+        const intercepted = interceptAnyObject(real, createFuncInterceptor(spy), createPropInterceptor(spy))
+        expect(intercepted()).toBe('real')
+    })
+
+    it('should not intercept non object-like values - primitives', () => {
+        const spy: LogSpy = jest.fn()
+        const real = 'real'
+        const intercepted = interceptAnyObject(
+            // @ts-ignore
+            real,
+            createFuncInterceptor(spy),
+            createPropInterceptor(spy)
+        )
+        expect(intercepted).toBe('real')
+    })
+
+    it('should not intercept non object-like values - arrays', () => {
+        const spy: LogSpy = jest.fn()
+        const real = ['real']
+        const intercepted = interceptAnyObject(real, createFuncInterceptor(spy), createPropInterceptor(spy))
+        expect(intercepted).toEqual(['real'])
+    })
+
+    it('should not intercept non object-like values - maps', () => {
+        const spy: LogSpy = jest.fn()
+        const real = new Map<string, string>([['key', 'value']])
+        const intercepted = interceptAnyObject(real, createFuncInterceptor(spy), createPropInterceptor(spy))
+        expect(intercepted.get('key')).toEqual('value')
     })
 })


### PR DESCRIPTION
## Bug Description 

shell.getAPI returns empty objects for several APIs even though real implementation was contributed.

## Problem
When the repluggable host is created with the `disableMonitoring` option off, `monitorAPI` is used to intercept and monitor any function in the API. This is done by contributing an intercepted API object instead of the contributed API. The intercepted API object is created using `interceptAnyObject`, that recursively intercepts all functions in the nested object and wraps them with monitoring logic. 

The problem is that `interceptAnyObject` assumes the API is a plain object, as can be seen by its type. When passed an API that is not a plain object (e.g. a function), `_.mapValues` returns an empty object and the API implementation is lost.

**The assumption that API is a plain object is wrong:** APIs are not obligated to be built using a plain object, and can be really anything, from objects to functions to primitives. This can be seen in the `TAPI` type that makes no assumptions of the shape of the API. 

## Solution

1. Changed the type of the `inner` argument in `interceptAnyObject` to be any, and instead added a type guard to make sure we only intercept plain objects.
2. Replaced the `_.isObjectLike` check with `_.isPlainObject` [which is more restrictive](https://lodash.com/docs/4.17.15#isObjectLike:~:text=_.isPlainObject(value)) (will return false for arrays, maps, etc)
3. Added sanity tests