### PR TITLE
use render function instead of createRoot

### DIFF
--- a/testKit/index.tsx
+++ b/testKit/index.tsx
@@ -1,7 +1,7 @@
 import { create, act, ReactTestRenderer, ReactTestInstance, TestRendererOptions } from 'react-test-renderer'
 import _ from 'lodash'
 import React, { ReactElement } from 'react'
-import { createRoot } from 'react-dom/client'
+import ReactDOM from 'react-dom'
 import { EntryPoint, ObservableState, PrivateShell, ShellBoundaryAspect } from '../src/API'
 import { AnySlotKey, AppHost, AppMainView, createAppHost as _createAppHost, EntryPointOrPackage, Shell, SlotKey } from '../src/index'
 import { ShellRenderer } from '../src/renderSlotComponents'
@@ -141,8 +141,7 @@ export const renderDOMInHost = (reactElement: ReactElement<any>, host: AppHost =
     )
 
     const container = document.body.querySelector('div')
-    const root = container && createRoot(container)
-    root?.render(Component)
+    ReactDOM.render(Component, container)
 }
 
 export const renderInHost = (


### PR DESCRIPTION
use render instead of create root to support other packages with react versions ^16