### PR TITLE
Move SlotKey type to core

### DIFF
--- a/packages/repluggable-core/src/API.ts
+++ b/packages/repluggable-core/src/API.ts
@@ -1,0 +1,31 @@
+export interface AnySlotKey {
+    readonly name: string
+    readonly public?: boolean // TODO: Move to new interface - APIKey
+}
+
+/**
+ * A key that represents an {ExtensionSlot} of shape T that's held in the {AppHost}
+ * Created be calling {Shell.declareSlot}
+ * Retrieved by calling {Shell.getSlot} (scoped to specific {Shell})
+ *
+ * @export
+ * @interface SlotKey
+ * @extends {AnySlotKey}
+ * @template T
+ */
+export interface SlotKey<T> extends AnySlotKey {
+    /**
+     * Holds no value, only triggers type-checking of T
+     */
+    readonly empty?: T
+    /**
+     * Application layer/layers that will restrict usage of APIs contributed by this entry point.
+     * Layers hierarchy is defined in the host options
+     * @See {AppHostOptions.layers}
+     */
+    readonly layer?: string | string[] // TODO: Move to new interface - APIKey
+    /**
+     * Version of the API that will be part of the API key unique identification
+     */
+    readonly version?: number // TODO: Move to new interface - APIKey
+}

--- a/packages/repluggable-core/src/index.ts
+++ b/packages/repluggable-core/src/index.ts
@@ -1,1 +1,4 @@
-export const x: number = 1
+export  {
+    AnySlotKey,
+    SlotKey
+} from "./API"

--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import * as Redux from 'redux'
 import { ThrottledStore } from './throttledStore'
+import { SlotKey, AnySlotKey } from 'repluggable-core'
+
+export {SlotKey, AnySlotKey} 
 
 export { AppHostAPI } from './appHostServices'
 
@@ -26,37 +29,6 @@ export interface LazyEntryPointDescriptor {
     readonly factory: LazyEntryPointFactory
 }
 
-export interface AnySlotKey {
-    readonly name: string
-    readonly public?: boolean // TODO: Move to new interface - APIKey
-}
-
-/**
- * A key that represents an {ExtensionSlot} of shape T that's held in the {AppHost}
- * Created be calling {Shell.declareSlot}
- * Retrieved by calling {Shell.getSlot} (scoped to specific {Shell})
- *
- * @export
- * @interface SlotKey
- * @extends {AnySlotKey}
- * @template T
- */
-export interface SlotKey<T> extends AnySlotKey {
-    /**
-     * Holds no value, only triggers type-checking of T
-     */
-    readonly empty?: T
-    /**
-     * Application layer/layers that will restrict usage of APIs contributed by this entry point.
-     * Layers hierarchy is defined in the host options
-     * @See {AppHostOptions.layers}
-     */
-    readonly layer?: string | string[] // TODO: Move to new interface - APIKey
-    /**
-     * Version of the API that will be part of the API key unique identification
-     */
-    readonly version?: number // TODO: Move to new interface - APIKey
-}
 
 /**
  * Application part that will receive a {Shell} when loaded into the {AppHost}


### PR DESCRIPTION
This pr is the initial pr which moving things to repluggable-core, the type of slotKey to be consumed from repluggable-core.