### PR TITLE
Adjust `Github Actions` workflows to the new setup

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,6 @@ jobs:
       - name: install, build, and test
         run: |
           yarn
-          cd packages/repluggable
           yarn build
           yarn test
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,40 +10,55 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 20
+      - name: Set PR version
+        run: | 
+          echo "DEPLOY_PREVIEW_VERSION=0.0.0-pr$PR_ID.$BUILD_NUMBER" >> $GITHUB_ENV
+          echo "DEPLOY_PREVIEW_TAG=pr$PR_ID.$BUILD_NUMBER" >> $GITHUB_ENV
+        env:
+          PR_ID: ${{ github.event.number }}
+          BUILD_NUMBER: ${{ github.run_number }}
+
       - name: Install dependencies
         run: yarn install
 
-      - name: Build package
-        run: |
-          cd packages/repluggable 
-          yarn build
+      - name: Build packages
+        run: yarn build
 
       - name: Run tests
-        run: |
-          cd packages/repluggable 
-          yarn test
+        run: yarn test
 
-      - name: Bump version
+      - name: Bump versions
         run: |
           git reset --hard
-          cd packages/repluggable
-          echo yarn version "0.0.0-pr$PR_ID.$BUILD_NUMBER"
-          yarn version "0.0.0-pr$PR_ID.$BUILD_NUMBER"
+          echo "Deploy preview version: '$DEPLOY_PREVIEW_VERSION'"
+
+          # Bumping repluggable-core & repluggable versions
+          yarn workspace repluggable-core version "$DEPLOY_PREVIEW_VERSION"
+          yarn workspace repluggable version "$DEPLOY_PREVIEW_VERSION"
+
+          # Adding the new version of repluggable-core to repluggable
+          export CORE_VERSION=$(npm pkg get version --workspace=repluggable-core | awk -F ': ' '{print $2}' | tr -d ' }"' | xargs)
+          echo "repluggable-core version is $CORE_VERSION, adding it to repluggable"
+          yarn workspace repluggable add repluggable-core@$CORE_VERSION
+          
           git status -vv
-          yarn build
           git add . || true
           git commit -m "Bump prerelease version" || true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          PR_ID: ${{ github.event.number }}
-          BUILD_NUMBER: ${{ github.run_number }}
 
-      - name: npm publish
+      - name: npm publish repluggable-core
         run: |
-          cd packages/repluggable
-          echo PR package tag is [pr$PR_ID.$BUILD_NUMBER]
-          npm publish --tag "pr$PR_ID.$BUILD_NUMBER"
+          echo "Publishing repluggable with tag: [$DEPLOY_PREVIEW_TAG]"
+          npm publish --workspace repluggable-core --tag "$DEPLOY_PREVIEW_TAG"
+          echo "::notice::repluggable-core@$DEPLOY_PREVIEW_VERSION"
         env:
           NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
-          PR_ID: ${{ github.event.number }}
-          BUILD_NUMBER: ${{ github.run_number }}
+      
+      - name: npm publish repluggable
+        run: |
+          echo "Publishing repluggable with tag: [$DEPLOY_PREVIEW_TAG]"
+          npm publish --workspace repluggable --tag "$DEPLOY_PREVIEW_TAG"
+          echo "::notice::repluggable@$DEPLOY_PREVIEW_VERSION"
+        env:
+          NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
           yarn workspace repluggable version "$DEPLOY_PREVIEW_VERSION"
 
           # Adding the new version of repluggable-core to repluggable
-          export CORE_VERSION=$(npm pkg get version --workspace=repluggable-core | awk -F ': ' '{print $2}' | tr -d ' }"' | xargs)
+          export CORE_VERSION=$(npm pkg get version --workspace=repluggable-core | jq -r '."repluggable-core"')
           echo "repluggable-core version is $CORE_VERSION, adding it to repluggable"
           yarn workspace repluggable add repluggable-core@$CORE_VERSION
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
           git reset --hard
           yarn workspace replupluggable-core version ${{ github.event.inputs.yarnVersionArgs }}
           yarn workspace replupluggable version ${{ github.event.inputs.yarnVersionArgs }}
-          export NEW_CORE_RELEASE_VERSION=$(npm pkg get version --workspace=repluggable-core | awk -F ': ' '{print $2}' | tr -d ' }"' | xargs)
-          export NEW_REPLUGGABLE_RELEASE_VERSION=$(npm pkg get version --workspace=repluggable | awk -F ': ' '{print $2}' | tr -d ' }"' | xargs)
+          export NEW_CORE_RELEASE_VERSION=$(npm pkg get version --workspace=repluggable-core | jq -r '."repluggable-core"')
+          export NEW_REPLUGGABLE_RELEASE_VERSION=$(npm pkg get version --workspace=repluggable | jq -r '."repluggable"')
           echo repluggable-core New Release Version is: [$NEW_CORE_RELEASE_VERSION]
           echo repluggable New Release Version is: [$NEW_REPLUGGABLE_RELEASE_VERSION]
           yarn workspace repluggable add repluggable-core@$NEW_CORE_RELEASE_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,23 +33,33 @@ jobs:
       - name: Bump version
         run: |
           git reset --hard
-          cd packages/repluggable
-          yarn version ${{ github.event.inputs.yarnVersionArgs }}
-          export NEW_RELEASE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
-          echo New Release Version is: [$NEW_RELEASE_VERSION]
+          yarn workspace replupluggable-core version ${{ github.event.inputs.yarnVersionArgs }}
+          yarn workspace replupluggable version ${{ github.event.inputs.yarnVersionArgs }}
+          export NEW_CORE_RELEASE_VERSION=$(npm pkg get version --workspace=repluggable-core | awk -F ': ' '{print $2}' | tr -d ' }"' | xargs)
+          export NEW_REPLUGGABLE_RELEASE_VERSION=$(npm pkg get version --workspace=repluggable | awk -F ': ' '{print $2}' | tr -d ' }"' | xargs)
+          echo repluggable-core New Release Version is: [$NEW_CORE_RELEASE_VERSION]
+          echo repluggable New Release Version is: [$NEW_REPLUGGABLE_RELEASE_VERSION]
+          yarn workspace repluggable add repluggable-core@$NEW_CORE_RELEASE_VERSION
           yarn build
           yarn test
           git add . || true
-          git commit -m "Release v$NEW_RELEASE_VERSION" || true
-          git tag -a "v$NEW_RELEASE_VERSION" -m "Release v$NEW_RELEASE_VERSION"
+          git commit -m "Release v$NEW_REPLUGGABLE_RELEASE_VERSION" || true
+          git tag -a "v$NEW_REPLUGGABLE_RELEASE_VERSION" -m "Release v$NEW_REPLUGGABLE_RELEASE_VERSION"
           git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
           git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" --tags
+          echo "::notice::repluggable-core@NEW_CORE_RELEASE_VERSION"
+          echo "::notice::repluggable@NEW_REPLUGGABLE_RELEASE_VERSION"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: npm publish
+      - name: npm publish repluggable-core
         run: |
-          cd packages/repluggable
-          npm publish
+          npm publish --workspace repluggable-core
+        env:
+          NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+
+      - name: npm publish repluggable
+        run: |
+          npm publish --workspace repluggable
         env:
           NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-registry "https://registry.npmjs.org"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,19 @@
+logFilters:
+  - code: YN0002
+    level: discard
+  - code: YN0007
+    level: discard
+  - code: YN0013
+    level: discard
+  - code: YN0032
+    level: discard
+  - code: YN0060
+    level: discard
+  - code: YN0061
+    level: discard
+
+npmRegistryServer: "https://registry.npmjs.org"
+
 nmMode: hardlinks-local
 
 nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
   "scripts": {
     "start": "yarn workspace repluggable start",
     "build": "yarn workspaces foreach --all --topological --parallel run build",
-    "test": "yarn workspace repluggable test",
-    "posttest": "yarn workspace repluggable posttest",
-    "lintfix": "yarn workspace repluggable lintfix"
+    "test": "yarn workspaces foreach --all --topological --parallel run test"
   },
   "devDependencies": {
     "husky": "^4.3.0",

--- a/packages/repluggable-core/package.json
+++ b/packages/repluggable-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repluggable-core",
-  "version": "1.0.0",
+  "version": "1.302.62",
   "license": "MIT",
   "description": "Allows composition of a React-with-Redux application entirely from a list of pluggable packages",
   "main": "dist/src/index.js",


### PR DESCRIPTION
This PR goal is to adjust the Github Actions workflows for the new monorepo setup.
`repluggable-core` and `repluggable` versions should be synced and coupled for each release.
So in every publish flow (deploy preview or release) we set `repluggable`'s dependency to `repluggable-core@current-version`

We use `yarn workspaces` power to run inner scripts from the root directory.
From the root directory, `build` and `test` run the correlate script in all packages in a topological order.