### PR TITLE
Make ThrottledStore server compatible

### DIFF
--- a/packages/repluggable/src/throttledStore.tsx
+++ b/packages/repluggable/src/throttledStore.tsx
@@ -20,7 +20,7 @@ interface AnyShellAction extends AnyAction {
 function createTimeOutPublisher ( notify: () => void)  {
     let id : null | NodeJS.Timeout =  null 
     return () => {
-        if (!id) {
+        if (id === null) {
             id = setTimeout(() => {
                 id = null
                 notify()
@@ -39,7 +39,7 @@ function createTimeOutPublisher ( notify: () => void)  {
 function createAnimationFramePublisher ( notify: () => void)  {
     let id : null | number =  null 
     return () => {
-        if (!id) {
+        if (id === null) {
             id = requestAnimationFrame(() => {
                 id = null
                 notify()


### PR DESCRIPTION
This pr goal is to make the throttle store work also on server.
1. not use request animation frame and instead use setTimeout with 0, publish to the next frame.
2. Change the names which will be more server compatibly in the spirt of observer pattern with a publisher. 