### PR TITLE
Remove unused variables from input for throttled store

### DIFF
--- a/packages/repluggable/src/appHost.tsx
+++ b/packages/repluggable/src/appHost.tsx
@@ -659,8 +659,6 @@ miss: ${memoizedWithMissHit.miss}
             store = createThrottledStore(
                 host,
                 contributedState,
-                window.requestAnimationFrame,
-                window.cancelAnimationFrame,
                 notifySubscribersIsRunning => {
                     isStoreSubscribersNotifyInProgress = notifySubscribersIsRunning
                 },

--- a/packages/repluggable/src/throttledStore.tsx
+++ b/packages/repluggable/src/throttledStore.tsx
@@ -176,8 +176,6 @@ export const updateThrottledStore = (
 export const createThrottledStore = (
     host: AppHost & AppHostServicesProvider,
     contributedState: ExtensionSlot<StateContribution>,
-    requestAnimationFrame: Window['requestAnimationFrame'],
-    cancelAnimationFrame: Window['cancelAnimationFrame'],
     updateIsSubscriptionNotifyInProgress: (isSubscriptionNotifyInProgress: boolean) => void,
     updateIsObserversNotifyInProgress: (isObserversNotifyInProgress: boolean) => void,
     updateShouldFlushMemoizationSync: (shouldFlushMemoizationSync: boolean) => void


### PR DESCRIPTION
This pr is just a pr to remove the variables I forgot to remove in the last pr of throttled store.

https://github.com/wix-incubator/repluggable/commit/ac03fce318c5044f79fb946470e7a17b0748bb3e

