### PR TITLE
Implement hasAPI  & hasSlot

### DIFF
--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -216,6 +216,14 @@ export interface AppHost {
      */
     getSlot<TItem>(key: SlotKey<TItem>): ExtensionSlot<TItem>
     /**
+     * Check if an extension slot is defined on the host
+     *
+     * @template TItem
+     * @param {SlotKey<TItem>} key
+     * @return {boolean}
+     */
+    hasSlot<TItem>(key: SlotKey<TItem>): boolean
+    /**
      * Get all the extension slots defined on the host
      *
      * @return {*}  {AnySlotKey[]}

--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -29,8 +29,6 @@ export interface LazyEntryPointDescriptor {
     readonly factory: LazyEntryPointFactory
 }
 
-
-
 /**
  * Application part that will receive a {Shell} when loaded into the {AppHost}
  * @export
@@ -201,6 +199,14 @@ export interface AppHost {
      * @return {*}  {TAPI}
      */
     getAPI<TAPI>(key: SlotKey<TAPI>): TAPI
+    /**
+     * Check if an implementation of API previously contributed to the {AppHost}
+     *
+     * @template TAPI
+     * @param {SlotKey<TAPI>} key API Key
+     * @return {*}  {boolean}
+     */
+    hasAPI<TAPI>(key: SlotKey<TAPI>): boolean
     /**
      * Get an extension slot defined on the host
      *

--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -29,6 +29,8 @@ export interface LazyEntryPointDescriptor {
     readonly factory: LazyEntryPointFactory
 }
 
+
+
 /**
  * Application part that will receive a {Shell} when loaded into the {AppHost}
  * @export

--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -200,7 +200,7 @@ export interface AppHost {
      */
     getAPI<TAPI>(key: SlotKey<TAPI>): TAPI
     /**
-     * Check if an implementation of API previously contributed to the {AppHost}
+     * Check if an API implementation has been contributed to the {AppHost}
      *
      * @template TAPI
      * @param {SlotKey<TAPI>} key API Key
@@ -216,7 +216,7 @@ export interface AppHost {
      */
     getSlot<TItem>(key: SlotKey<TItem>): ExtensionSlot<TItem>
     /**
-     * Check if an extension slot is defined on the host
+     * Check if an extension slot has been contributed to the {AppHost}
      *
      * @template TItem
      * @param {SlotKey<TItem>} key

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -140,11 +140,9 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
     const trace: Trace[] = []
     const memoizedArr: StatisticsMemoization[] = []
 
-    // use this to subscribe to the IOC container changes
     const readyAPIs = new Set<AnySlotKey>()
 
     const uniqueShellNames = new Set<string>()
-    // or this
     const extensionSlots = new Map<AnySlotKey, AnyExtensionSlot>()
     const slotKeysByName = new Map<string, AnySlotKey>()
     const addedShells = new Map<string, PrivateShell>()

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -539,22 +539,25 @@ miss: ${memoizedWithMissHit.miss}
         return extensionSlots.has(ownKey)
     }
 
-    function getAPI<TAPI>(key: SlotKey<TAPI>): TAPI {
+    function tryGetAPI<TAPI>(key: SlotKey<TAPI>): TAPI | undefined {
+        if (!hasSlot(key)) {
+            return undefined
+        }
         const APISlot = getSlot<TAPI>(key)
         const item = APISlot.getSingleItem()
-        if (item) {
-            return item.contribution
+        return item?.contribution
+    }
+
+    function getAPI<TAPI>(key: SlotKey<TAPI>): TAPI {
+        const api = tryGetAPI(key)
+        if (!api) {
+            throw new Error(`API '${slotKeyToName(key)}' doesn't exist.`)
         }
-        throw new Error(`API '${slotKeyToName(key)}' doesn't exist.`)
+        return api
     }
 
     function hasAPI<TAPI>(key: SlotKey<TAPI>): boolean {
-        if (!hasSlot(key)) {
-            return false
-        }
-        const APISlot = getSlot<TAPI>(key)
-        const item = APISlot.getSingleItem()
-        return !!item
+        return !!tryGetAPI(key)
     }
 
     function executeWhenFree(key: string, callback: () => void): void {

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -541,7 +541,7 @@ miss: ${memoizedWithMissHit.miss}
 
     function tryGetAPI<TAPI>(key: SlotKey<TAPI>): TAPI | undefined {
         if (!hasSlot(key)) {
-            return undefined
+            return
         }
         const APISlot = getSlot<TAPI>(key)
         const item = APISlot.getSingleItem()

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -50,6 +50,7 @@ import {
     ThrottledStore,
     updateThrottledStore
 } from './throttledStore'
+import _ from 'lodash'
 
 function isMultiArray<T>(v: T[] | T[][]): v is T[][] {
     return _.every(v, _.isArray)

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -161,7 +161,6 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
         getAppHostOptions: () => options
     }
     const appHostServicesEntryPoint = createAppHostServicesEntryPoint(() => hostAPI)
-    const hasAPI = (key: AnySlotKey) => readyAPIs.has(key)
     const host: PrivateAppHost & AppHostServicesProvider = {
         getStore,
         getAPI,
@@ -543,6 +542,12 @@ miss: ${memoizedWithMissHit.miss}
             return item.contribution
         }
         throw new Error(`API '${slotKeyToName(key)}' doesn't exist.`)
+    }
+
+    function hasAPI<TAPI>(key: SlotKey<TAPI>): boolean {
+        const APISlot = getSlot<TAPI>(key)
+        const item = APISlot.getSingleItem()
+        return !!item
     }
 
     function executeWhenFree(key: string, callback: () => void): void {

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -551,6 +551,9 @@ miss: ${memoizedWithMissHit.miss}
     }
 
     function hasAPI<TAPI>(key: SlotKey<TAPI>): boolean {
+        if (!hasSlot(key)) {
+            return false
+        }
         const APISlot = getSlot<TAPI>(key)
         const item = APISlot.getSingleItem()
         return !!item

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -997,7 +997,7 @@ miss: ${memoizedWithMissHit.miss}
             },
 
             hasAPI<TAPI>(key: SlotKey<TAPI>): boolean {
-                return (dependencyAPIs.has(key) || isOwnContributedAPI(key)) && hasAPI(key)
+                return (dependencyAPIs.has(key) || isOwnContributedAPI(key)) && host.hasAPI(key)
             },
 
             contributeAPI<TAPI>(key: SlotKey<TAPI>, factory: () => TAPI, apiOptions?: ContributeAPIOptions<TAPI>): TAPI {

--- a/packages/repluggable/src/connectWithShell.tsx
+++ b/packages/repluggable/src/connectWithShell.tsx
@@ -167,15 +167,12 @@ function wrapWithShellContext<State, OwnProps, StateProps, DispatchProps>(
     )
 }
 
-
-
 function wrapWithShellRenderer<OwnProps>(
     boundShell: Shell,
     component: ComponentWithChildrenProps<OwnProps>
 ): ComponentWithChildrenProps<OwnProps> {
     const host = (boundShell as PrivateShell).TEMP_getAppHost()
-    return (props: WithChildren<OwnProps>) => 
-        <ShellRenderer shell={boundShell} component={component(props)} host={host} />
+    return (props: WithChildren<OwnProps>) => <ShellRenderer shell={boundShell} component={component(props)} host={host} />
 }
 
 export interface ConnectWithShellOptions<OwnProps, StateProps> {

--- a/packages/repluggable/src/throttledStore.tsx
+++ b/packages/repluggable/src/throttledStore.tsx
@@ -16,17 +16,18 @@ interface AnyShellAction extends AnyAction {
     __shellName?: string
 }
 
-function createTimeOutPublisher(notify: () => void) {
-    let id: null | NodeJS.Timeout = null
+
+function createTimeOutPublisher ( notify: () => void)  {
+    let id : null | NodeJS.Timeout =  null 
     return () => {
         if (id === null) {
             id = setTimeout(() => {
                 id = null
                 notify()
-            }, 0)
+            },0)
         }
         return () => {
-            if (id === null) {
+            if(id === null) {
                 return
             }
             clearTimeout(id)
@@ -35,8 +36,8 @@ function createTimeOutPublisher(notify: () => void) {
     }
 }
 
-function createAnimationFramePublisher(notify: () => void) {
-    let id: null | number = null
+function createAnimationFramePublisher ( notify: () => void)  {
+    let id : null | number =  null 
     return () => {
         if (id === null) {
             id = requestAnimationFrame(() => {
@@ -45,7 +46,7 @@ function createAnimationFramePublisher(notify: () => void) {
             })
         }
         return () => {
-            if (id === null) {
+            if(id === null) {
                 return
             }
             cancelAnimationFrame(id)
@@ -53,6 +54,9 @@ function createAnimationFramePublisher(notify: () => void) {
         }
     }
 }
+
+
+
 
 type Subscriber = () => void
 
@@ -248,8 +252,10 @@ export const createThrottledStore = (
         notifyAll()
     }
 
-    const notifyAllOnPublish =
-        typeof window === 'undefined' ? createTimeOutPublisher(scheduledNotifyAll) : createAnimationFramePublisher(scheduledNotifyAll)
+
+   
+
+    const notifyAllOnPublish = typeof window === 'undefined' ? createTimeOutPublisher(scheduledNotifyAll) : createAnimationFramePublisher(scheduledNotifyAll)
 
     let cancelRender = _.noop
 

--- a/packages/repluggable/src/throttledStore.tsx
+++ b/packages/repluggable/src/throttledStore.tsx
@@ -16,18 +16,17 @@ interface AnyShellAction extends AnyAction {
     __shellName?: string
 }
 
-
-function createTimeOutPublisher ( notify: () => void)  {
-    let id : null | NodeJS.Timeout =  null 
+function createTimeOutPublisher(notify: () => void) {
+    let id: null | NodeJS.Timeout = null
     return () => {
         if (id === null) {
             id = setTimeout(() => {
                 id = null
                 notify()
-            },0)
+            }, 0)
         }
         return () => {
-            if(id === null) {
+            if (id === null) {
                 return
             }
             clearTimeout(id)
@@ -36,8 +35,8 @@ function createTimeOutPublisher ( notify: () => void)  {
     }
 }
 
-function createAnimationFramePublisher ( notify: () => void)  {
-    let id : null | number =  null 
+function createAnimationFramePublisher(notify: () => void) {
+    let id: null | number = null
     return () => {
         if (id === null) {
             id = requestAnimationFrame(() => {
@@ -46,7 +45,7 @@ function createAnimationFramePublisher ( notify: () => void)  {
             })
         }
         return () => {
-            if(id === null) {
+            if (id === null) {
                 return
             }
             cancelAnimationFrame(id)
@@ -54,9 +53,6 @@ function createAnimationFramePublisher ( notify: () => void)  {
         }
     }
 }
-
-
-
 
 type Subscriber = () => void
 
@@ -252,10 +248,8 @@ export const createThrottledStore = (
         notifyAll()
     }
 
-
-   
-
-    const notifyAllOnPublish = typeof window === 'undefined' ? createTimeOutPublisher(scheduledNotifyAll) : createAnimationFramePublisher(scheduledNotifyAll)
+    const notifyAllOnPublish =
+        typeof window === 'undefined' ? createTimeOutPublisher(scheduledNotifyAll) : createAnimationFramePublisher(scheduledNotifyAll)
 
     let cancelRender = _.noop
 

--- a/packages/repluggable/testKit/index.tsx
+++ b/packages/repluggable/testKit/index.tsx
@@ -261,7 +261,7 @@ function createShell(host: AppHost): PrivateShell {
         lazyEvaluator: func => ({ get: func }),
         TEMP_getAppHost() {
             return host
-        },
+        }
     }
 }
 

--- a/packages/repluggable/testKit/mockPackage.ts
+++ b/packages/repluggable/testKit/mockPackage.ts
@@ -13,6 +13,7 @@ export interface MockPublicAPI {
 }
 
 export const MockAPI: SlotKey<MockAPI> = { name: 'mock API' }
+export const MockSlot: SlotKey<any> = { name: 'mock slot' }
 export const MockPublicAPI: SlotKey<MockPublicAPI> = {
     name: 'mock API public',
     public: true
@@ -95,5 +96,15 @@ export const mockPackageWithPublicAPI: EntryPoint = {
         shell.contributeAPI(MockPublicAPI, () => ({
             stubTrue: () => true
         }))
+    }
+}
+
+export const mockPackageWithSlot: EntryPoint = {
+    name: 'MOCK_PACKAGE_WITH_SLOT',
+    declareAPIs() {
+        return []
+    },
+    attach(shell: Shell) {
+        shell.declareSlot(MockSlot)
     }
 }


### PR DESCRIPTION
Implement `hasAPI` and `hasSlot` functions, to allow checking if some API\Slot exist on the host\shell.
Note that same as `getAPI` and `getSlot`, the implementation is slightly different between the host and the shell.