### PR TITLE
Remove shell renderer from host

### DIFF
--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -468,7 +468,8 @@ export interface PrivateShell extends Shell {
     setLifecycleState(enableStore: boolean, enableAPIs: boolean, initCompleted: boolean): void
     getBoundaryAspects(): ShellBoundaryAspect[]
     getHostOptions(): AppHostOptions
-    getAppHost(): AppHost
+    // @restricted - for internal use of repluggable only
+    TEMP_getAppHost(): AppHost
 }
 
 export interface EntryPointsInfo {

--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -468,7 +468,7 @@ export interface PrivateShell extends Shell {
     setLifecycleState(enableStore: boolean, enableAPIs: boolean, initCompleted: boolean): void
     getBoundaryAspects(): ShellBoundaryAspect[]
     getHostOptions(): AppHostOptions
-    wrapWithShellRenderer(component: JSX.Element): JSX.Element
+    getAppHost(): AppHost
 }
 
 export interface EntryPointsInfo {

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -1,4 +1,3 @@
-import React from 'react'
 import { AnyAction, Store } from 'redux'
 import {
     AnyEntryPoint,
@@ -51,7 +50,6 @@ import { ConsoleHostLogger, createShellLogger } from './loggers'
 import { monitorAPI } from './monitorAPI'
 import { getCycle, Graph, Tarjan } from './tarjanGraph'
 import { setupDebugInfo } from './repluggableAppDebug'
-import { ShellRenderer } from '.'
 import { IterableWeakMap } from './IterableWeakMap'
 
 function isMultiArray<T>(v: T[] | T[][]): v is T[][] {
@@ -1109,9 +1107,8 @@ miss: ${memoizedWithMissHit.miss}
 
             log: createShellLogger(host, entryPoint),
 
-            wrapWithShellRenderer(component): JSX.Element {
-                return <ShellRenderer shell={shell} component={component} host={host} />
-            },
+            getAppHost: () => host,
+
             lazyEvaluator
         }
 

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -1107,7 +1107,7 @@ miss: ${memoizedWithMissHit.miss}
 
             log: createShellLogger(host, entryPoint),
 
-            getAppHost: () => host,
+            TEMP_getAppHost: () => host,
 
             lazyEvaluator
         }

--- a/packages/repluggable/src/connectWithShell.tsx
+++ b/packages/repluggable/src/connectWithShell.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from './errorBoundary'
 import { ShellContext } from './shellContext'
 import { StoreContext } from './storeContext'
 import { propsDeepEqual } from './propsDeepEqual'
+import { ShellRenderer } from './renderSlotComponents'
 
 interface WrapperMembers<State, OwnProps, StateProps, DispatchProps> {
     connectedComponent: any
@@ -166,11 +167,15 @@ function wrapWithShellContext<State, OwnProps, StateProps, DispatchProps>(
     )
 }
 
+
+
 function wrapWithShellRenderer<OwnProps>(
     boundShell: Shell,
     component: ComponentWithChildrenProps<OwnProps>
 ): ComponentWithChildrenProps<OwnProps> {
-    return (props: WithChildren<OwnProps>) => (boundShell as PrivateShell).wrapWithShellRenderer(component(props))
+    const host = (boundShell as PrivateShell).getAppHost()
+    return (props: WithChildren<OwnProps>) => 
+        <ShellRenderer shell={boundShell} component={component(props)} host={host} />
 }
 
 export interface ConnectWithShellOptions<OwnProps, StateProps> {

--- a/packages/repluggable/src/connectWithShell.tsx
+++ b/packages/repluggable/src/connectWithShell.tsx
@@ -173,7 +173,7 @@ function wrapWithShellRenderer<OwnProps>(
     boundShell: Shell,
     component: ComponentWithChildrenProps<OwnProps>
 ): ComponentWithChildrenProps<OwnProps> {
-    const host = (boundShell as PrivateShell).getAppHost()
+    const host = (boundShell as PrivateShell).TEMP_getAppHost()
     return (props: WithChildren<OwnProps>) => 
         <ShellRenderer shell={boundShell} component={component(props)} host={host} />
 }

--- a/packages/repluggable/testKit/index.tsx
+++ b/packages/repluggable/testKit/index.tsx
@@ -258,8 +258,10 @@ function createShell(host: AppHost): PrivateShell {
         clearCache: _.noop,
         getHostOptions: () => host.options,
         log: createShellLogger(host, entryPoint),
-        wrapWithShellRenderer: (component: JSX.Element) => component,
-        lazyEvaluator: func => ({ get: func })
+        lazyEvaluator: func => ({ get: func }),
+        getAppHost() {
+            return host
+        },
     }
 }
 

--- a/packages/repluggable/testKit/index.tsx
+++ b/packages/repluggable/testKit/index.tsx
@@ -259,7 +259,7 @@ function createShell(host: AppHost): PrivateShell {
         getHostOptions: () => host.options,
         log: createShellLogger(host, entryPoint),
         lazyEvaluator: func => ({ get: func }),
-        getAppHost() {
+        TEMP_getAppHost() {
             return host
         },
     }


### PR DESCRIPTION
This pr is part of the effort to make repluggable server compatible. 

I remove React from app host by deleting the only function which uses react wrapWithShellRenderer.

to do that I add into the privateShell one function to get the Host.
Its ok as it only in the private shell which is used only inside repluggable. 

then using the host connectWithShell create his own wrapWithShellRenderer so only when needed we use React.

for now the appHost is exposed via TEMP_getAppHost in the future will will replace the access only via privateSymbol of repluggable