### PR TITLE
getOwnSlotKey by name if the declared key is public

### DIFF
--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -598,12 +598,10 @@ miss: ${memoizedWithMissHit.miss}
     }
 
     function getOwnSlotKey<T>(key: SlotKey<T>): SlotKey<T> {
-        if (key.public === true) {
-            const ownKey = slotKeysByName.get(slotKeyToName(key))
+        const ownKey = slotKeysByName.get(slotKeyToName(key))
             if (ownKey && ownKey.public) {
                 return ownKey as SlotKey<T>
             }
-        }
         return key
     }
 


### PR DESCRIPTION
Given a slot key, `getOwnSlotKey` returns the original slot key with which the slot was declared (from slotKeysByName) if it's public, otherwise returns the input key unchanged.

Since we only care about whether the original slot key was public, we can directly check this condition after retrieving the key from slotKeysByName, allowing getting public slots without having the `public` property explicitly stated on the argument key.