### PR TITLE
Fix throttled store bug

### DIFF
--- a/packages/repluggable/src/throttledStore.ts
+++ b/packages/repluggable/src/throttledStore.ts
@@ -18,39 +18,39 @@ interface AnyShellAction extends AnyAction {
 
 
 function createTimeOutPublisher ( notify: () => void)  {
-    let id : null | NodeJS.Timeout =  null 
+    let id : undefined | NodeJS.Timeout =  undefined 
     return () => {
-        if (id === null) {
+        if (id === undefined) {
             id = setTimeout(() => {
-                id = null
+                id = undefined
                 notify()
             },0)
         }
         return () => {
-            if(id === null) {
+            if(id === undefined) {
                 return
             }
             clearTimeout(id)
-            id = null
+            id = undefined
         }
     }
 }
 
 function createAnimationFramePublisher ( notify: () => void)  {
-    let id : null | number =  null 
+    let id : undefined | number =  undefined 
     return () => {
-        if (id === null) {
+        if (id === undefined) {
             id = requestAnimationFrame(() => {
-                id = null
+                id = undefined
                 notify()
             })
         }
         return () => {
-            if(id === null) {
+            if(id === undefined) {
                 return
             }
             cancelAnimationFrame(id)
-            id = null
+            id = undefined
         }
     }
 }


### PR DESCRIPTION
In my last refactor of throttled store I introduced a very nice bug.
this is the pr: https://github.com/wix-incubator/repluggable/pull/280.

the bug happened because before the change the check was using:
`!requestId` i wanted to be more explicit and used `id === null`

but if you put null and don't refernce the id anymore its garbage collected and become undefined which means that we will not invoke any subscribers int he future.  


this pr fixes it by using `undefined` for the default value for the id.

we can think on adding test in feature prs but we want to unblock bump of repluggable as fast as possible