### PR TITLE
Fix forbidden export test

### DIFF
--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -1,10 +1,40 @@
 import * as React from 'react'
 import * as Redux from 'redux'
 import { ThrottledStore } from './throttledStore'
-import { SlotKey, AnySlotKey } from 'repluggable-core'
 import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core/'
 
-export { AnySlotKey, SlotKey }
+
+export interface AnySlotKey {
+    readonly name: string
+    readonly public?: boolean // TODO: Move to new interface - APIKey
+}
+
+/**
+ * A key that represents an {ExtensionSlot} of shape T that's held in the {AppHost}
+ * Created be calling {Shell.declareSlot}
+ * Retrieved by calling {Shell.getSlot} (scoped to specific {Shell})
+ *
+ * @export
+ * @interface SlotKey
+ * @extends {AnySlotKey}
+ * @template T
+ */
+export interface SlotKey<T> extends AnySlotKey {
+    /**
+     * Holds no value, only triggers type-checking of T
+     */
+    readonly empty?: T
+    /**
+     * Application layer/layers that will restrict usage of APIs contributed by this entry point.
+     * Layers hierarchy is defined in the host options
+     * @See {AppHostOptions.layers}
+     */
+    readonly layer?: string | string[] // TODO: Move to new interface - APIKey
+    /**
+     * Version of the API that will be part of the API key unique identification
+     */
+    readonly version?: number // TODO: Move to new interface - APIKey
+}
 
 export { AppHostAPI } from './appHostServices'
 


### PR DESCRIPTION
This change copy the type of SlotKey back into 'repluggable' so the forbidden export test should pass.

Why the test fail?
If you are making a re-export for some reason that complicated test fails, so in order to unblock other repos to update repluggable I copy it back in until I will properly move everything into repluggable core without breaking that test.