### PR TITLE
On declarations changed

### DIFF
--- a/packages/repluggable-core/src/API.ts
+++ b/packages/repluggable-core/src/API.ts
@@ -43,6 +43,8 @@ export interface EntryPointTags {
 }
 export type LazyEntryPointFactory = () => Promise<EntryPoint> //TODO: get rid of these
 export type ShellsChangedCallback = (shellNames: string[]) => void
+export type DeclarationsChangedCallback = () => void
+export type UnsubscribeFromDeclarationsChanged = () => void
 export type ShellBoundaryAspect = React.FunctionComponent<React.PropsWithChildren<unknown>>
 
 export interface LazyEntryPointDescriptor {
@@ -259,6 +261,16 @@ export interface AppHost {
      * @return {Promise<void>}
      */
     removeShells(names: string[]): Promise<void>
+        /**
+     * Subscribe to changes in host declarations. This includes:
+     * - API additions and removals
+     * - Extension slot additions and removals
+     *
+     * @param {DeclarationsChangedCallback} callback Function to be called when host declarations change
+     * @return {UnsubscribeFromDeclarationsChanged} Function to unsubscribe from host declarations changes
+     */
+
+    onDeclarationsChanged(callback: DeclarationsChangedCallback): UnsubscribeFromDeclarationsChanged
     onShellsChanged(callback: ShellsChangedCallback): string
     removeShellsChangedCallback(callbackId: string): void
     readonly log: HostLogger

--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as Redux from 'redux'
-import { AnySlotKey, SlotKey } from 'repluggable-core'
 import { ThrottledStore } from './throttledStore'
 import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core/'
 

--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as Redux from 'redux'
+import { AnySlotKey, SlotKey } from 'repluggable-core'
 import { ThrottledStore } from './throttledStore'
 import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core/'
 
@@ -53,14 +54,14 @@ export interface EntryPointTags {
 }
 export type LazyEntryPointFactory = () => Promise<EntryPoint> //TODO: get rid of these
 export type ShellsChangedCallback = (shellNames: string[]) => void
+export type DeclarationsChangedCallback = () => void
+export type UnsubscribeFromDeclarationsChanged = () => void
 export type ShellBoundaryAspect = React.FunctionComponent<React.PropsWithChildren<unknown>>
 
 export interface LazyEntryPointDescriptor {
     readonly name: string
     readonly factory: LazyEntryPointFactory
 }
-
-
 
 /**
  * Application part that will receive a {Shell} when loaded into the {AppHost}
@@ -207,10 +208,6 @@ export interface ExtensionItem<T> {
     readonly uniqueId: string
 }
 
-// addEntryPoints(entryPoints: EntryPoint[])
-// addPackages(packages: EntryPointOrPackage[])
-//
-
 /**
  * An application content container that will accept {EntryPoint} and provide registry for contracts
  *
@@ -291,6 +288,16 @@ export interface AppHost {
      * @return {Promise<void>}
      */
     removeShells(names: string[]): Promise<void>
+    /**
+     * Subscribe to changes in host declarations. This includes:
+     * - API additions and removals
+     * - Extension slot additions and removals
+     *
+     * @param {DeclarationsChangedCallback} callback Function to be called when host declarations change
+     * @return {UnsubscribeFromDeclarationsChanged} Function to unsubscribe from host declarations changes
+     */
+
+    onDeclarationsChanged(callback: DeclarationsChangedCallback): UnsubscribeFromDeclarationsChanged
     onShellsChanged(callback: ShellsChangedCallback): string
     removeShellsChangedCallback(callbackId: string): void
     readonly log: HostLogger

--- a/packages/repluggable/test/appHost.spec.ts
+++ b/packages/repluggable/test/appHost.spec.ts
@@ -16,14 +16,16 @@ import {
 } from '../src/API'
 import {
     addMockShell,
+    asyncLoadMockPackage,
+    dependsOnMockPackageEntryPoint,
     emptyLoggerOptions,
     MockAPI,
     mockPackage,
     mockPackageWithPublicAPI,
+    mockPackageWithSlot,
     MockPublicAPI,
     mockShellInitialState,
     mockShellStateKey,
-    mockPackageWithSlot,
     MockSlot
 } from '../testKit'
 
@@ -1723,6 +1725,41 @@ describe('App Host', () => {
 
             await host.addShells(entryPoints)
             expect(spy).toBeCalledTimes(1)
+        })
+    })
+
+    describe('Host.onDeclarationsChanged', () => {
+        it('should be called once for an entry point attach phase', () => {
+            const host = createAppHost([], testHostOptions)
+            const spy = jest.fn()
+            host.onDeclarationsChanged(spy)
+            host.addShells([mockPackage, dependsOnMockPackageEntryPoint, mockPackageWithSlot])
+            expect(spy).toBeCalledTimes(1)
+        })
+        it('should be called once for an entry point detach phase', () => {
+            const host = createAppHost([], testHostOptions)
+            const spy = jest.fn()
+            host.onDeclarationsChanged(spy)
+            host.addShells([mockPackage, dependsOnMockPackageEntryPoint, mockPackageWithSlot])
+            expect(spy).toBeCalledTimes(1)
+            host.removeShells([mockPackage.name])
+            expect(spy).toBeCalledTimes(2)
+        })
+        it('should be called once for an async api contribution in the extend phase', () => {
+            const host = createAppHost([], testHostOptions)
+            const spy = jest.fn()
+            host.onDeclarationsChanged(spy)
+            host.addShells([asyncLoadMockPackage])
+            expect(spy).toBeCalledTimes(1)
+        })
+        it('should be called for a slot declaration outside of an entry point', () => {
+            const host = createAppHost([], testHostOptions)
+            const spy = jest.fn()
+            host.onDeclarationsChanged(spy)
+            const shell = addMockShell(host)
+            expect(spy).toBeCalledTimes(1)
+            shell.declareSlot(MockSlot)
+            expect(spy).toBeCalledTimes(2)
         })
     })
 })


### PR DESCRIPTION
Add `onDeclarationsChanged` API, to register callbacks that will be called when a host declaration has changed. This includes declaring a slot or contributing an API. 
To avoid an overhead, `onDeclarationsChanged` callbacks are batch-executed. This means that for an entry point attach \ extend phase, `onDeclarationsChanged` will be called only once for all new declarations in that phase. Same for removing declarations in the entry point detach phase.