### PR TITLE
remove testkit package json as the repluggable package JSON exports all

### DIFF
--- a/packages/repluggable/testKit/package.json
+++ b/packages/repluggable/testKit/package.json
@@ -1,3 +1,0 @@
-{
-  "main": "../dist/testKit/index.js"
-}


### PR DESCRIPTION
the package json inside the testkit creates a type problem because the types are taken from the dist.

to overcome this problem we remove the package.json in the testkit folder, it is not needed as the package.json file in the repluggable package (not in the root) has files: "*", which basically exports everything including the testkit.