### PR TITLE
Allow getting private apis in testkit

### DIFF
--- a/packages/repluggable/src/API.ts
+++ b/packages/repluggable/src/API.ts
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Redux from 'redux'
 import { ThrottledStore } from './throttledStore'
 import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core/'
+import { INTERNAL_DISABLE_PRIVATE_CHECK_IN_TESTKIT } from './__internal'
 
 
 export interface AnySlotKey {
@@ -332,6 +333,7 @@ export interface AppHostOptions {
     readonly monitoring: MonitoringOptions
     readonly layers?: APILayer[] | APILayer[][]
     readonly disableLayersValidation?: boolean
+    readonly disablePrivateCheck?: typeof INTERNAL_DISABLE_PRIVATE_CHECK_IN_TESTKIT;
     readonly disableCheckCircularDependencies?: boolean
     readonly enableStickyErrorBoundaries?: boolean
     readonly enableReduxDevtoolsExtension?: boolean

--- a/packages/repluggable/src/__internal.ts
+++ b/packages/repluggable/src/__internal.ts
@@ -1,0 +1,4 @@
+/**
+ * This symbol is only for allowing getting private APIs in testkit.
+ */
+export const INTERNAL_DISABLE_PRIVATE_CHECK_IN_TESTKIT: unique symbol = Symbol('DISABLE_PRIVATE_CHECK_IN_TESTKIT')

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -1,5 +1,6 @@
-import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core'
 import _ from 'lodash'
+import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core'
+import { INTERNAL_DISABLE_PRIVATE_CHECK_IN_TESTKIT } from './__internal'
 import { AnyAction, Store } from 'redux'
 import {
     AnyEntryPoint,
@@ -136,7 +137,7 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
 
     verifyLayersUniqueness(options.layers)
 
-    const unReadyEntryPointsStore = createUnreadyEntryPointsStore()
+    const disablePrivateCheck = options.disablePrivateCheck === INTERNAL_DISABLE_PRIVATE_CHECK_IN_TESTKIT;
 
     const layers: InternalAPILayer[][] = _.map(options.layers ? castMultiArray(options.layers) : [], (singleDimension, i) =>
         _.map(singleDimension, layer => ({ ...layer, dimension: i }))
@@ -662,9 +663,9 @@ miss: ${memoizedWithMissHit.miss}
     }
 
     function getOwnSlotKey<T>(key: SlotKey<T>): SlotKey<T> {
-        if (key.public === true) {
+        if (key.public === true || disablePrivateCheck ) {
             const ownKey = slotKeysByName.get(slotKeyToName(key))
-            if (ownKey && ownKey.public) {
+            if (ownKey && ownKey.public || disablePrivateCheck) {
                 return ownKey as SlotKey<T>
             }
         }

--- a/packages/repluggable/src/appHost.ts
+++ b/packages/repluggable/src/appHost.ts
@@ -137,6 +137,7 @@ export function createAppHost(initialEntryPointsOrPackages: EntryPointOrPackage[
 
     verifyLayersUniqueness(options.layers)
 
+    const unReadyEntryPointsStore = createUnreadyEntryPointsStore()
     const disablePrivateCheck = options.disablePrivateCheck === INTERNAL_DISABLE_PRIVATE_CHECK_IN_TESTKIT;
 
     const layers: InternalAPILayer[][] = _.map(options.layers ? castMultiArray(options.layers) : [], (singleDimension, i) =>

--- a/packages/repluggable/test/appHost.spec.ts
+++ b/packages/repluggable/test/appHost.spec.ts
@@ -467,42 +467,50 @@ describe('App Host', () => {
         })
 
         describe('private API slot key', () => {
-            it('should equal itself', () => {
-                const host = createAppHost([mockPackage], testHostOptions)
+            const testHostOptionsForPrivateAPI: AppHostOptions[] = [
+                testHostOptions,
+                {...testHostOptions, disablePrivateCheck: true as any}, // we do type case here to emulate possible input from consumers
+                {...testHostOptions, disablePrivateCheck: 'true' as any}, // we do type case here to emulate possible input from consumers
+            ]
 
-                const API = host.getAPI(MockAPI)
-
-                expect(API).toBeTruthy()
-            })
-
-            it('should not equal another key with same name', () => {
-                const host = createAppHost([mockPackage], testHostOptions)
-                const fakeKey: SlotKey<MockAPI> = { name: MockAPI.name }
-
-                expect(() => {
-                    host.getAPI(fakeKey)
-                }).toThrowError(new RegExp(MockAPI.name))
-            })
-
-            it('should not equal another key with same name that claims it is public', () => {
-                const host = createAppHost([mockPackage], testHostOptions)
-                const fakeKey1: SlotKey<MockAPI> = {
-                    name: MockAPI.name,
-                    public: true
-                }
-                const fakeKey2: SlotKey<MockAPI> = {
-                    name: MockAPI.name,
-                    public: false
-                }
-                const fakeKey3: any = {
-                    name: MockAPI.name,
-                    public: 'zzz'
-                }
-
-                expect(() => host.getAPI(fakeKey1)).toThrowError(new RegExp(MockAPI.name))
-                expect(() => host.getAPI(fakeKey2)).toThrowError(new RegExp(MockAPI.name))
-                expect(() => host.getAPI(fakeKey3)).toThrowError(new RegExp(MockAPI.name))
-            })
+            for (const _testHostOptions of testHostOptionsForPrivateAPI ) {
+                it('should equal itself', () => {
+                    const host = createAppHost([mockPackage], _testHostOptions)
+    
+                    const API = host.getAPI(MockAPI)
+    
+                    expect(API).toBeTruthy()
+                })
+    
+                it('should not equal another key with same name', () => {
+                    const host = createAppHost([mockPackage], _testHostOptions)
+                    const fakeKey: SlotKey<MockAPI> = { name: MockAPI.name }
+    
+                    expect(() => {
+                        host.getAPI(fakeKey)
+                    }).toThrowError(new RegExp(MockAPI.name))
+                })
+    
+                it('should not equal another key with same name that claims it is public', () => {
+                    const host = createAppHost([mockPackage], _testHostOptions)
+                    const fakeKey1: SlotKey<MockAPI> = {
+                        name: MockAPI.name,
+                        public: true
+                    }
+                    const fakeKey2: SlotKey<MockAPI> = {
+                        name: MockAPI.name,
+                        public: false
+                    }
+                    const fakeKey3: any = {
+                        name: MockAPI.name,
+                        public: 'zzz'
+                    }
+    
+                    expect(() => host.getAPI(fakeKey1)).toThrowError(new RegExp(MockAPI.name))
+                    expect(() => host.getAPI(fakeKey2)).toThrowError(new RegExp(MockAPI.name))
+                    expect(() => host.getAPI(fakeKey3)).toThrowError(new RegExp(MockAPI.name))
+                })
+            }
         })
 
         describe('public API slot key', () => {

--- a/packages/repluggable/test/testKit.spec.tsx
+++ b/packages/repluggable/test/testKit.spec.tsx
@@ -128,6 +128,27 @@ describe('App Host TestKit', () => {
         expect(host.getAPI(key).f()).toBe(1)
     })
 
+    it('should return private APIs by value', () => {
+        const PrivateAPI = {
+            name: 'private API',
+            public: false,
+        };
+
+        const host = createAppHostWithPacts([{
+            name: 'MOCK',
+            declareAPIs() {
+                return [PrivateAPI]
+            },
+            attach(shell) {
+                shell.contributeAPI(PrivateAPI, () => ({ getSomething: () => 'something' }))
+            }
+        }], [])
+
+        const privateAPI = host.getAPI({...PrivateAPI});
+
+        expect(privateAPI).toBeDefined();
+    })
+
     describe('createAppHostAndWaitForLoading', () => {
         beforeAll(() => {
             jest.useFakeTimers()

--- a/packages/repluggable/testKit/index.tsx
+++ b/packages/repluggable/testKit/index.tsx
@@ -8,6 +8,7 @@ import { ShellRenderer } from '../src/renderSlotComponents'
 import { createShellLogger } from '../src/loggers'
 import { emptyLoggerOptions } from './emptyLoggerOptions'
 import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core'
+import { INTERNAL_DISABLE_PRIVATE_CHECK_IN_TESTKIT } from '../src/__internal'
 
 export { emptyLoggerOptions }
 export { AppHost } from '../src/index'
@@ -79,7 +80,7 @@ export function createAppHostWithPacts(packages: EntryPointOrPackage[], pacts: P
         }
     }
 
-    return createAppHost([...packages, pactsEntryPoint], { ...emptyLoggerOptions, disableLayersValidation: true })
+    return createAppHost([...packages, pactsEntryPoint], { ...emptyLoggerOptions, disableLayersValidation: true, disablePrivateCheck: INTERNAL_DISABLE_PRIVATE_CHECK_IN_TESTKIT })
 }
 
 export async function createAppHostAndWaitForLoading(packages: EntryPointOrPackage[], pacts: PactAPIBase[]): Promise<AppHost> {


### PR DESCRIPTION
in order to override private APIs (for example APIs the do network) in tests we need the option to "ease" repluggable a bit to allow accessing private APIs.

this change is only relevant to the testkit host and not to the host itself.

to prevent actual users of repluggable to access private APIs we do the following:
- update the options to add a new option to allow this change
- declare a unique symbol that is only accessible from within repluggable
- use this symbol to create host in the testkit