### PR TITLE
Revert "remove testkit package json as the repluggable package JSON exports all"

### DIFF
--- a/packages/repluggable/testKit/package.json
+++ b/packages/repluggable/testKit/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../dist/testKit/index.js"
+}


### PR DESCRIPTION
Reverts wix-incubator/repluggable#299

This pr breaks REP:
![CleanShot 2025-04-14 at 16 25 37](https://github.com/user-attachments/assets/42900714-3272-4b44-9d95-15f64b7fcf0f)

as it tries to bring the code from src and not from dist