### PR TITLE
Export `repluggable/debug`

### DIFF
--- a/packages/repluggable-core/debug/index.ts
+++ b/packages/repluggable-core/debug/index.ts
@@ -1,0 +1,1 @@
+export { RepluggableAppDebugInfo, APIDebugInfo } from '../src/repluggableAppDebug/debug'

--- a/packages/repluggable-core/package.json
+++ b/packages/repluggable-core/package.json
@@ -11,9 +11,10 @@
     "email": "responsive-feds@wix.com"
   },
   "scripts": {
-    "build": "rm -rf dist && yarn build-cjs && yarn build-es",
+    "build": "rm -rf dist && yarn build-cjs && yarn build-es && yarn build-debug",
     "build-cjs": "tsc --outDir dist --module commonjs",
     "build-es": "tsc --outDir dist/es --module esNext",
+    "build-debug": "tsc --project tsconfig.debug.json",
     "test": "jest --coverage",
     "posttest": "tslint --project ."
   },

--- a/packages/repluggable-core/tsconfig.debug.json
+++ b/packages/repluggable-core/tsconfig.debug.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "outDir": "dist/debug"
+  },
+  "include": [
+    "debug"
+  ]
+}

--- a/packages/repluggable/debug/index.ts
+++ b/packages/repluggable/debug/index.ts
@@ -1,0 +1,1 @@
+export { RepluggableAppDebugInfo, APIDebugInfo } from 'repluggable-core/debug'

--- a/packages/repluggable/package.json
+++ b/packages/repluggable/package.json
@@ -23,9 +23,10 @@
   ],
   "scripts": {
     "start": "webpack-dev-server --hot --config webpack.local.config.js",
-    "build": "rm -rf dist && yarn build-cjs && yarn build-es && yarn build-bundle-dev && yarn build-bundle-prod",
+    "build": "rm -rf dist && yarn build-cjs && yarn build-es && yarn build-debug && yarn build-bundle-dev && yarn build-bundle-prod",
     "build-cjs": "tsc --outDir dist --module commonjs",
     "build-es": "tsc --outDir dist/es --module esNext",
+    "build-debug": "tsc --project tsconfig.debug.json",
     "build-bundle-dev": "webpack --config webpack.dev.config.js",
     "build-bundle-prod": "webpack --config webpack.prod.config.js",
     "test": "jest --coverage",

--- a/packages/repluggable/tsconfig.debug.json
+++ b/packages/repluggable/tsconfig.debug.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "outDir": "dist/debug"
+  },
+  "include": [
+    "debug"
+  ]
+}


### PR DESCRIPTION
### Add `repluggableAppDebugInfo` Type Import and Window Declaration Update

This PR introduces the ability to import the `repluggableAppDebugInfo` type and extends the `window` declaration accordingly.

#### Example Usage:

```ts
import 'repluggable/debug'
// or: import 'repluggable-core/debug'

const apis = window.repluggableAppDebug.utils.apis;
```

You can also import the actual types:
```
import { RepluggableAppDebugInfo, APIDebugInfo} from 'repluggable/debug'
```


> **Note:** Importing from `'repluggable'` will not pollute the global object.
