### PR TITLE
TestKit| createAppHostAndWaitForLoading: filtered packages according to pacts

### DIFF
--- a/packages/repluggable-core/test/testKit.spec.tsx
+++ b/packages/repluggable-core/test/testKit.spec.tsx
@@ -12,7 +12,7 @@ import {
     asyncLoadMockPackage,
     dependsOnMockPackageEntryPoint,
     MockPublicAPI,
-    createAppHostAndWaitForLoading
+    createAppHostAndWaitForLoading, mockPackageWithPublicAPI
 } from '../testKit'
 
 interface APIKeys {
@@ -148,6 +148,19 @@ describe('App Host TestKit', () => {
             const hostPromise = createAppHostAndWaitForLoading([dependsOnMockPackageEntryPoint], [])
             jest.runAllTimers()
             await expect(hostPromise).rejects.toThrow(new RegExp(MockPublicAPI.name))
+        })
+
+        it('should replace the api with pact if provided', async () => {
+            const pactAPI: MockPublicAPI & PactAPI<MockPublicAPI> = {
+                getAPIKey: () => MockPublicAPI,
+                stubTrue: () => false
+            }
+
+            const hostPromise = createAppHostAndWaitForLoading([mockPackageWithPublicAPI], [pactAPI])
+            jest.runAllTimers()
+            const host = await hostPromise
+            const api = host.getAPI(MockPublicAPI)
+            expect(api.stubTrue()).toBeFalsy()
         })
     })
 })


### PR DESCRIPTION

[REP reference](https://github.com/wix-private/responsive-editor-packages/blob/6b9236e08b1c0d72dca8a0fa77f2fc3cac701a95/packages/responsive-editor-integration-testkit/src/testkit.ts)

when create an `appHost` in the testkit, passing a mock `pact` of an API requires also adding its package to the `ignoredPackages`, otherwise we get an error 
`Extension slot with key '${slotName}' already exists.`

therefore, when we add a `pact` we also need to add the package to ignore (duplication, prone to errors)
this PR changes the `createAppHostAndWaitForLoading` function to filter out the packages that their apis is being mocked.