### PR TITLE
Add an optional check for unready entry points waiting for private API consumed as public

### DIFF
--- a/packages/repluggable-core/src/API.ts
+++ b/packages/repluggable-core/src/API.ts
@@ -298,6 +298,13 @@ export interface AppHost {
     onDeclarationsChanged(callback: DeclarationsChangedCallback): UnsubscribeFromDeclarationsChanged
     onShellsChanged(callback: ShellsChangedCallback): string
     removeShellsChangedCallback(callbackId: string): void
+    /**
+     * Verify if there are pending entry points waiting for APIs that will never be available.
+     * This usually happens when trying to consume a private API as a public API.
+     *
+     * @throws {Error} If there are pending entry points with API mismatches
+     */
+    verifyPendingEntryPointsAPIsMismatch(): void
     readonly log: HostLogger
     readonly options: AppHostOptions
 }


### PR DESCRIPTION
# Add verifyPendingEntryPointsAPIsMismatch method

## Summary
Adds a method to detect when pending entry points are waiting for private APIs that will never be available due to public/private mismatches.

## Changes
- Added `verifyPendingEntryPointsAPIsMismatch()` to `AppHost` interface
- Implemented detection logic that checks ready APIs against pending dependencies
- Throws descriptive error when private APIs are being consumed as public
- Added test coverage for the mismatch scenario

## Why
Prevents entry points from getting stuck waiting for APIs that will never be available, making dependency issues easier to debug during development.