### PR TITLE
fix(connectWithShell): key the shell context wrapper around children

### DIFF
--- a/packages/repluggable/src/connectWithShell.tsx
+++ b/packages/repluggable/src/connectWithShell.tsx
@@ -12,6 +12,11 @@ import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core'
 
 const ANONYMOUS_COMPONENT = 'Anonymous Component'
 
+// The shell context wrapper around `children` is created dynamically, so React cannot mark it as key-validated at
+// element creation time. Without an explicit key, rendering `{props.children}` alongside siblings makes React report
+// "Each child in a list should have a unique key prop" for the wrapper.
+const SHELL_CONTEXT_CHILDREN_KEY = 'repluggable-shell-context'
+
 function resolveComponentName(component: React.ComponentType<any>, optionsComponentName?: string): string {
     return optionsComponentName ?? component.displayName ?? component.name ?? ANONYMOUS_COMPONENT
 }
@@ -174,7 +179,11 @@ function wrapWithShellContext<State, OwnProps, StateProps, DispatchProps>(
         props.children
             ? {
                   ...props,
-                  children: <ShellContext.Provider value={originalShell}>{props.children}</ShellContext.Provider>
+                  children: (
+                      <ShellContext.Provider key={SHELL_CONTEXT_CHILDREN_KEY} value={originalShell}>
+                          {props.children}
+                      </ShellContext.Provider>
+                  )
               }
             : props
 

--- a/packages/repluggable/src/connectWithShell.tsx
+++ b/packages/repluggable/src/connectWithShell.tsx
@@ -12,9 +12,10 @@ import { INTERNAL_DONT_USE_SHELL_GET_APP_HOST } from 'repluggable-core'
 
 const ANONYMOUS_COMPONENT = 'Anonymous Component'
 
-// The shell context wrapper around `children` is created dynamically, so React cannot mark it as key-validated at
-// element creation time. Without an explicit key, rendering `{props.children}` alongside siblings makes React report
-// "Each child in a list should have a unique key prop" for the wrapper.
+// `wrapChildrenIfNeeded` builds this ShellContext.Provider around `children` dynamically, so React never
+// key-validates it at creation time. Once the wrapped children sit in a list position — a parent with several
+// children, or an array such as `.map` output — React key-checks every entry and reports
+// "Each child in a list should have a unique key prop" unless the wrapper carries a key.
 const SHELL_CONTEXT_CHILDREN_KEY = 'repluggable-shell-context'
 
 function resolveComponentName(component: React.ComponentType<any>, optionsComponentName?: string): string {

--- a/packages/repluggable/test/connectWithShell.spec.tsx
+++ b/packages/repluggable/test/connectWithShell.spec.tsx
@@ -630,6 +630,28 @@ describe('connectWithShell', () => {
         expect(collectAllTexts(testKit.root)).toContain(getValueFromState(getMockShellState(host)))
     })
 
+    it('should provide a key for the shell context wrapper of children', () => {
+        const { shell, renderInShellContext } = createMocks(mockPackage)
+
+        const captured: { children?: React.ReactNode } = {}
+        const PureCompWithChildren: FunctionComponent<{ children?: React.ReactNode }> = ({ children }) => {
+            captured.children = children
+            return <div>{children}</div>
+        }
+        const ConnectedCompWithChildren = connectWithShell(undefined, undefined, shell, { allowOutOfEntryPoint: true })(PureCompWithChildren)
+
+        renderInShellContext(
+            <ConnectedCompWithChildren>
+                <span />
+            </ConnectedCompWithChildren>
+        )
+
+        // without a key, React reports "Each child in a list should have a unique key prop" whenever the wrapped
+        // children are rendered next to sibling elements
+        expect(React.isValidElement(captured.children)).toBe(true)
+        expect((captured.children as ReactElement).key).not.toBeNull()
+    })
+
     it('should render contributed boundary aspect', () => {
         // arrange
         const { host, shell } = createMocks({


### PR DESCRIPTION
## What this fixes

React prints this warning in the browser console whenever a connected component renders `{props.children}` in a place where React handles children as a list:

```
Warning: Each child in a list should have a unique "key" prop.
    at div
    at PerspectiveProvider
    at MainViewPure
    ...
```

The warning appears on every load of the Wix Studio 2 editor. It is noise, but it hides real key problems and makes the console harder to read.

## Why it happens

`connectWithShell` re-provides the shell context around the children:

```tsx
children: <ShellContext.Provider value={originalShell}>{props.children}</ShellContext.Provider>
```

This element is created dynamically, inside `wrapChildrenIfNeeded`. React therefore never marks it as key-validated at creation time, and the element has no key.

React reconciles children in two different ways. A single child goes through a path that never looks at keys. Two or more children, or a child inside an array, become a list, and React checks a key for every entry in that list. The wrapper only warns on the second path:

| what the connected component renders | how React treats the children | warning? |
| --- | --- | --- |
| `<div>{props.children}</div>` | single child | no |
| `<div>{props.children}<Other /></div>` | list | **yes** |
| `{props.children}` inside an array, for example `.map` output | list | **yes** |
| two or more children, wrapper has a key (this PR) | list | no |

This is why the wrapper stays quiet in most connected components, and why it warns in `MainViewPure`, whose `div` has five children.

Only elements built by a **development** React build carry the `_store` marker that the reconciler checks. An app bundled for production does not, so its own keyless children stay silent. That is why the warning always points at repluggable's wrapper.

Evidence from a live editor page (React 18.3.1 development build), reading the fiber of the parent `div` and its children:

| child element | key | has React dev `_store` |
| --- | --- | --- |
| `ShellContext.Provider` (from repluggable) | `null` | **yes** |
| the app's own JSX children | `null` | no |

Only the repluggable wrapper can trigger the warning.

## The change

Give the wrapper a constant key. The key never changes, so reconciliation still matches the same wrapper across renders, and no component remounts.

I also added a test that checks the children wrapper has a key. The test fails without the source change and passes with it.

## Verification

- New test: fails on the old code, passes on the new code.
- Whole `repluggable` package suite: 99 tests, all pass.
- `yarn workspace repluggable run build`: passes.
- In a live editor page (React 18.3.1 development build) I rendered the wrapper through React's real reconciler in each of the cases in the table above. Only the two list cases without a key warn. Adding the key was the only change in the last case.

Note: locally the specs only run with `--globals '{"ts-jest":{"diagnostics":false}}'`. On a clean `master` the suite already fails to compile in my environment (TypeScript 5.4.5 with an older ts-jest), so this is not caused by the change.

