### PR TITLE
performance(slot-renderers): avoid rendering unchanged slot items

### DIFF
--- a/packages/repluggable/src/renderSlotComponents.tsx
+++ b/packages/repluggable/src/renderSlotComponents.tsx
@@ -70,12 +70,16 @@ function createSlotItemToShellRendererMap<T = any>(mapFunc?: SlotRendererIterato
 }
 
 type SlotRendererPure<T = any> = React.FunctionComponent<SlotRendererPureProps<T>>
+function areSlotItemsEqual<T>(next: ExtensionItem<T>[], previous: ExtensionItem<T>[]): boolean {
+    return next.length === previous.length && next.every((item, index) => item === previous[index])
+}
+
 const SlotRendererPure: SlotRendererPure = ({ items, mapFunc, filterFunc, sortFunc }) => (
     <>
         {_.flow(
             _.compact([
                 filterFunc && ((slotItems: typeof items) => slotItems.filter((item, index) => filterFunc(item.contribution, index))),
-                sortFunc && ((slotItems: typeof items) => slotItems.sort(sortFunc)),
+                sortFunc && ((slotItems: typeof items) => [...slotItems].sort(sortFunc)),
                 (slotItems: typeof items) => slotItems.map(createSlotItemToShellRendererMap(mapFunc))
             ])
         )(items)}
@@ -86,13 +90,23 @@ interface SlotRendererConnectedProps<T> extends SlotRendererIterators<T> {
     slot: ExtensionSlot<T>
 }
 
+function areSlotRendererStatePropsEqual<T>(
+    next: Pick<SlotRendererPureProps<T>, 'items'>,
+    previous: Pick<SlotRendererPureProps<T>, 'items'>
+): boolean {
+    return areSlotItemsEqual(next.items, previous.items)
+}
+
 const ConnectedSlot = connect(
     (state, { slot }: SlotRendererConnectedProps<any> & { renderCount: number }) => ({
         items: slot.getItems()
     }),
     undefined,
     undefined,
-    { context: StoreContext }
+    {
+        context: StoreContext,
+        areStatePropsEqual: areSlotRendererStatePropsEqual
+    }
 )(SlotRendererPure)
 
 export function SlotRenderer<T>(props: SlotRendererConnectedProps<T>): React.ReactElement<SlotRendererConnectedProps<T>> {

--- a/packages/repluggable/test/renderSlotComponents.spec.tsx
+++ b/packages/repluggable/test/renderSlotComponents.spec.tsx
@@ -1,10 +1,12 @@
 import _ from 'lodash'
 import React, { FunctionComponent, PropsWithChildren } from 'react'
 import { SlotKey, ReactComponentContributor, Shell } from '../src/API'
-import { createAppHost, addMockShell, renderInHost, connectWithShell, SlotRenderer } from '../testKit'
+import { createAppHost, addMockShell, renderInHost, connectWithShell, SlotRenderer, mockPackage, TOGGLE_MOCK_VALUE } from '../testKit'
 import { Provider } from 'react-redux'
 import { AnyAction, createStore } from 'redux'
 import { act, create, ReactTestRenderer } from 'react-test-renderer'
+import { StoreContext } from '../src/storeContext'
+import { SlotRenderer as DirectSlotRenderer } from '../src/renderSlotComponents'
 
 const CompA: FunctionComponent = () => <div id="A" className="mock-comp" />
 const CompB: FunctionComponent = () => <div id="B" className="mock-comp" />
@@ -94,6 +96,34 @@ describe('SlotRenderer', () => {
 
         expect(testKit.root.findAllByType(CompA).length).toBe(1)
         expect(testKit.root.findAllByType(CompB).length).toBe(0)
+    })
+
+    it('should not re-render when Redux state changes without changing slot items', () => {
+        const slotKey: SlotKey<ReactComponentContributor> = {
+            name: 'mock_key'
+        }
+        const host = createAppHost([mockPackage])
+        const shell = addMockShell(host)
+        const slot = shell.declareSlot(slotKey)
+        const filterFunc = jest.fn(() => true)
+
+        slot.contribute(shell, () => <CompA />)
+
+        act(() => {
+            create(
+                <Provider store={host.getStore()} context={StoreContext}>
+                    <DirectSlotRenderer slot={slot} filterFunc={filterFunc} />
+                </Provider>
+            )
+        })
+        const renderCountAfterMount = filterFunc.mock.calls.length
+
+        act(() => {
+            host.getStore().dispatch({ type: TOGGLE_MOCK_VALUE })
+            host.getStore().flush()
+        })
+
+        expect(filterFunc).toHaveBeenCalledTimes(renderCountAfterMount)
     })
 
     it('should sort slot items by sort function', () => {


### PR DESCRIPTION
## The Problem

When the Redux root-state reference changes, React-Redux reruns ConnectedSlot’s mapStateToProps. This calls `slot.getItems()`, which evaluates item conditions using `Array.filter()` and returns a *new array on every call*. React-
Redux uses shallow equality by default, so it considers the new items array changed and re-renders `SlotRendererPure`, even when the array contains the same `ExtensionItem` references in the same order.

https://github.com/wix-incubator/repluggable/blob/27738f7782df3239f769b2e54184ba54d9f870f6/packages/repluggable-core/src/extensionSlot.ts#L82

https://react-redux.js.org/using-react-redux/connect-mapstate#return-values-determine-if-your-component-re-renders

## The Solution

This PR adds a specialized equality function that compares the ordered `ExtensionItem` references rather than the identity of the containing array. Rendering is still triggered when an item is added, removed, replaced, reordered, or changes condition membership. Sorting now operates on a copy so it does not mutate the array retained for the next comparison.

_A note,
Unlike propsDeepEqual, this is a narrow O(n) identity comparison. propsDeepEqual recursively compares values and deliberately treats different functions as equal, which is unsafe for ExtensionItem condition functions._

## Measurements


Measured in Studio2 through a local repluggable build. Both React Profiler recordings contain approximately 15 seconds of the same interaction: panning the canvas without moving a component, editing content, or changing zoom.

| Metric | Before | With optimization | Change |
| --- | ---: | ---: | ---: |
| Capture duration | 14.444 s | 14.850 s | — |
| SlotRendererPure component updates | 36,356 | 0 | -100% |
| Total recorded fiber renders / second | 20,918 | 1,656 | -92.1% |
| Commits / second | 228.1 | 122.8 | -46.2% |
| Render duration / second | 86.2 ms | 28.9 ms | -66.5% |
| Effect duration / second | 402.0 ms | 75.2 ms | -81.3% |

Raw capture totals:

- before: 3,295 commits, 302,140 fiber render entries, 1,245 ms render duration, 5,807 ms effect duration
- with optimization: 1,823 commits, 24,594 fiber render entries, 429 ms render duration, 1,117 ms effect duration

These are separate interactive profiling recordings, not a controlled benchmark. They provide strong directional evidence that unchanged slot rendering is a major source of React work during canvas movement, but the percentages should not be read as an equivalent product-wide latency improvement.

## Risks

Main risk: `filterFunc` and `sortFunc` run inside SlotRendererPure. A filter or sorter that depends on changing external state could become stale while the raw ExtensionItem sequence remains unchanged. A follow-up can move filtering and sorting into mapStateToProps and compare the final visible order.

## Test

yarn workspace repluggable test renderSlotComponents.spec.tsx --runInBand

13 tests passed.



---

Same commit as #353 (`4635d8d`), re-opened from a branch in this repo so the PR preview publish can use npm Trusted Publishing — fork PRs get no OIDC token, which made the `publish` job fail with `E404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
